### PR TITLE
Address PR review findings in multi-connection metadata merge and export paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/LinkeD365/Metadata-Browser",
     "type": "git"
   },
+  "features": {
+    "multiConnection": "optional"
+  },
   "homepage": "https://github.com/LinkeD365/Metadata-Browser#readme",
   "bugs": {
     "url": "https://github.com/LinkeD365/Metadata-Browser/issues"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import { FluentProvider, webDarkTheme, webLightTheme } from "@fluentui/react-com
 import { RelationshipAttribute } from "./model/tableMeta";
 
 function App() {
-  const { connection, isLoading, refreshConnection } = useConnection();
+  const { primaryConnection, secondaryConnection, isLoading, refreshConnection } = useConnection();
 
   const { addLog } = useEventLog();
   const [theme, setTheme] = useState<string>("light");
@@ -68,65 +68,78 @@ function App() {
 
   const [viewModel] = useState(() => new ViewModel());
 
+  const loadSetting = useCallback(async <T,>(key: string, parser: (value: string) => T): Promise<T | null> => {
+    const value = await window.toolboxAPI.settings.get(key);
+    return value ? parser(value) : null;
+  }, []);
+
   useEffect(() => {
-    (async () => {
+    const loadDefaultSettings = async () => {
       try {
-        const savedColumns = await window.toolboxAPI.settings.get("defaultTableColumns");
+        const savedColumns = await loadSetting("defaultTableColumns", (value) =>
+          value.split(",").map((col: string) => col.trim()),
+        );
         if (savedColumns) {
-          viewModel.tableAttributes = savedColumns.split(",").map((col: string) => col.trim());
+          viewModel.tableAttributes = savedColumns;
         }
-        const savedColAttribs = await window.toolboxAPI.settings.get("defaultColumnAttributes");
+        const savedColAttribs = await loadSetting("defaultColumnAttributes", (value) => JSON.parse(value));
         if (savedColAttribs) {
-          Object.assign(viewModel.columnAttributes, JSON.parse(savedColAttribs));
+          Object.assign(viewModel.columnAttributes, savedColAttribs);
         }
         const relTypes = ["OneToManyRelationship", "ManyToOneRelationship", "ManyToManyRelationship"];
         for (const relType of relTypes) {
-          const savedRelAttribs = await window.toolboxAPI.settings.get("defaultRelationshipAttributes" + relType);
+          const savedRelAttribs = await loadSetting("defaultRelationshipAttributes" + relType, (value) =>
+            JSON.parse(value).map((attr: RelationshipAttribute) => {
+              return Object.assign(new RelationshipAttribute(), attr);
+            }),
+          );
           if (savedRelAttribs) {
-            viewModel.relationshipAttributes = viewModel.relationshipAttributes.concat(
-              JSON.parse(savedRelAttribs).map((attr: RelationshipAttribute) => {
-                return Object.assign(new RelationshipAttribute(), attr);
-              }),
-            );
+            viewModel.relationshipAttributes = viewModel.relationshipAttributes.concat(savedRelAttribs);
           }
         }
-        const savedViewAttribs = await window.toolboxAPI.settings.get("defaultViewAttributes");
+        const savedViewAttribs = await loadSetting("defaultViewAttributes", (value) => JSON.parse(value));
         if (savedViewAttribs) {
-          viewModel.viewAttributes = JSON.parse(savedViewAttribs);
+          viewModel.viewAttributes = savedViewAttribs;
         }
-        const savedBpfAttribs = await window.toolboxAPI.settings.get("defaultBusinessProcessFlowAttributes");
+        const savedBpfAttribs = await loadSetting("defaultBusinessProcessFlowAttributes", (value) => JSON.parse(value));
         if (savedBpfAttribs) {
-          viewModel.businessProcessFlowAttributes = JSON.parse(savedBpfAttribs);
+          viewModel.businessProcessFlowAttributes = savedBpfAttribs;
         }
-        const savedBusinessRuleAttribs = await window.toolboxAPI.settings.get("defaultBusinessRuleAttributes");
+        const savedBusinessRuleAttribs = await loadSetting("defaultBusinessRuleAttributes", (value) =>
+          JSON.parse(value),
+        );
         if (savedBusinessRuleAttribs) {
-          viewModel.businessRuleAttributes = JSON.parse(savedBusinessRuleAttribs);
+          viewModel.businessRuleAttributes = savedBusinessRuleAttribs;
         }
-        const excelExport = await window.toolboxAPI.settings.get("defaultExcelExportOptions");
+        const excelExport = await loadSetting("defaultExcelExportOptions", (value) => JSON.parse(value));
         if (excelExport) {
-          Object.assign(viewModel.excelOptions, JSON.parse(excelExport));
+          Object.assign(viewModel.excelOptions, excelExport);
         }
         addLog("Loaded default relationship attributes", "info");
       } catch (error) {
         console.error("Failed to load default settings:", error);
       }
-    })();
+    };
+
+    void loadDefaultSettings();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- viewModel is a stable reference that doesn't need to trigger re-runs
-  }, []);
+  }, [loadSetting, viewModel, addLog]);
   const dvSvc = useMemo(
     () =>
       new dvService({
-        connection: connection,
+        primaryConnection: primaryConnection,
+        secondaryConnection: secondaryConnection,
         dvApi: window.dataverseAPI,
         onLog: addLog,
       }),
-    [connection, addLog],
+    [primaryConnection, secondaryConnection, addLog],
   );
   return (
     <>
       <FluentProvider theme={theme === "dark" ? webDarkTheme : webLightTheme}>
         <MetadataBrowser
-          connection={connection}
+          primaryConnection={primaryConnection}
+          secondaryConnection={secondaryConnection}
           vm={viewModel}
           dvService={dvSvc}
           onLog={addLog}

--- a/src/components/BusinessProcessFlows.tsx
+++ b/src/components/BusinessProcessFlows.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react";
 import { dvService } from "../utils/dataverse";
 import { TableMeta } from "../model/tableMeta";
 import { Spinner } from "@fluentui/react-components";
-import { ColDef } from "ag-grid-community";
+import { ColDef, RowStyleModule } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { BusinessProcessFlowMeta } from "../model/businessProcessFlow";
@@ -91,7 +91,14 @@ export const BusinessProcessFlows = observer((props: BusinessProcessFlowsProps):
 
   const colDefs = React.useMemo<ColDef<BusinessProcessFlowMeta>[]>(
     () => [
-      { headerName: "Name", field: "flowName", flex: 2, sort: "asc" },
+      {
+        headerName: "Name",
+        field: "flowName",
+        flex: 2,
+        sort: "asc",
+        valueGetter: (params) =>
+          secondaryConnection && !params.data?.hasPrimaryConnection ? "" : (params.data?.flowName ?? ""),
+      },
       ...(secondaryConnection
         ? [
             {
@@ -131,6 +138,7 @@ export const BusinessProcessFlows = observer((props: BusinessProcessFlowsProps):
     <div style={{ width: "98vw", height: "85vh", alignSelf: "center" }}>
       <AgGridReact<BusinessProcessFlowMeta>
         theme={agGridTheme}
+        modules={[RowStyleModule]}
         rowData={filteredFlows}
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}

--- a/src/components/BusinessProcessFlows.tsx
+++ b/src/components/BusinessProcessFlows.tsx
@@ -70,6 +70,7 @@ export const BusinessProcessFlows = observer((props: BusinessProcessFlowsProps):
       secondaryFlows,
       (flow) => flow.flowName,
       (flow) => flow.flowName,
+      ["flowName"],
     );
     onLog(
       `Loaded ${selectedTable.businessProcessFlows.length} business process flows for table: ${selectedTable.tableName}`,

--- a/src/components/BusinessProcessFlows.tsx
+++ b/src/components/BusinessProcessFlows.tsx
@@ -7,9 +7,11 @@ import { ColDef } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { BusinessProcessFlowMeta } from "../model/businessProcessFlow";
+import { createConnectionRowClassRules, mergeConnectionComparisonRecords } from "../utils/connectionComparison";
 
 interface BusinessProcessFlowsProps {
   connection: ToolBoxAPI.DataverseConnection | null;
+  secondaryConnection: ToolBoxAPI.DataverseConnection | null;
   dvService: dvService;
   isLoading: boolean;
   selectedTable: TableMeta;
@@ -19,7 +21,15 @@ interface BusinessProcessFlowsProps {
 }
 
 export const BusinessProcessFlows = observer((props: BusinessProcessFlowsProps): React.JSX.Element => {
-  const { connection, dvService, onLog, selectedTable, showNotification, businessProcessFlowAttributes } = props;
+  const {
+    connection,
+    secondaryConnection,
+    dvService,
+    onLog,
+    selectedTable,
+    showNotification,
+    businessProcessFlowAttributes,
+  } = props;
   const [loadingMeta, setLoadingMeta] = React.useState(false);
 
   const filteredFlows = React.useMemo(() => {
@@ -41,21 +51,30 @@ export const BusinessProcessFlows = observer((props: BusinessProcessFlowsProps):
   }, [selectedTable]);
 
   async function getBusinessProcessFlows() {
-    if (!connection) {
+    const canLoadPrimary = Boolean(connection && selectedTable.hasPrimaryConnection);
+    const canLoadSecondary = Boolean(secondaryConnection && selectedTable.hasSecondaryConnection);
+
+    if (!canLoadPrimary && !canLoadSecondary) {
       await showNotification("No Connection", "Please connect to a Dataverse environment", "warning");
       return;
     }
 
     setLoadingMeta(true);
-    await dvService
-      .getBusinessProcessFlowsForTable(selectedTable)
-      .then((flows) => {
-        selectedTable.businessProcessFlows = flows;
-        onLog(`Loaded ${flows.length} business process flows for table: ${selectedTable.tableName}`, "success");
-      })
-      .catch((error: { message: any }) => {
-        onLog(`Error loading business process flows for table ${selectedTable.tableName}: ${error.message}`, "error");
-      });
+    const [primaryFlows, secondaryFlows] = await Promise.all([
+      canLoadPrimary ? dvService.getBusinessProcessFlowsForTable(selectedTable, "primary") : Promise.resolve([]),
+      canLoadSecondary ? dvService.getBusinessProcessFlowsForTable(selectedTable, "secondary") : Promise.resolve([]),
+    ]);
+
+    selectedTable.businessProcessFlows = mergeConnectionComparisonRecords(
+      primaryFlows,
+      secondaryFlows,
+      (flow) => flow.flowName,
+      (flow) => flow.flowName,
+    );
+    onLog(
+      `Loaded ${selectedTable.businessProcessFlows.length} business process flows for table: ${selectedTable.tableName}`,
+      "success",
+    );
     setLoadingMeta(false);
   }
 
@@ -73,6 +92,16 @@ export const BusinessProcessFlows = observer((props: BusinessProcessFlowsProps):
   const colDefs = React.useMemo<ColDef<BusinessProcessFlowMeta>[]>(
     () => [
       { headerName: "Name", field: "flowName", flex: 2, sort: "asc" },
+      ...(secondaryConnection
+        ? [
+            {
+              headerName: secondaryConnection.name ? `2nd Name (${secondaryConnection.name})` : "2nd Name",
+              field: "secondaryDisplayName",
+              valueGetter: (params) =>
+                params.data?.hasSecondaryConnection ? params.data.secondaryDisplayName || "" : "",
+            } as ColDef<BusinessProcessFlowMeta>,
+          ]
+        : []),
       { headerName: "Type", field: "type" },
       ...businessProcessFlowAttributes.map(
         (attrName) =>
@@ -85,7 +114,12 @@ export const BusinessProcessFlows = observer((props: BusinessProcessFlowsProps):
           }) as ColDef<BusinessProcessFlowMeta>,
       ),
     ],
-    [businessProcessFlowAttributes],
+    [businessProcessFlowAttributes, secondaryConnection],
+  );
+
+  const rowClassRules = React.useMemo(
+    () => createConnectionRowClassRules<BusinessProcessFlowMeta>(Boolean(secondaryConnection)),
+    [secondaryConnection],
   );
 
   const getFlowRowId = React.useCallback((flow: BusinessProcessFlowMeta) => {
@@ -101,6 +135,7 @@ export const BusinessProcessFlows = observer((props: BusinessProcessFlowsProps):
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}
         domLayout="normal"
+        rowClassRules={rowClassRules}
         getRowId={(params) => (params.data ? getFlowRowId(params.data) : "")}
         enableCellTextSelection={true}
       />

--- a/src/components/BusinessRules.tsx
+++ b/src/components/BusinessRules.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react";
 import { dvService } from "../utils/dataverse";
 import { TableMeta } from "../model/tableMeta";
 import { Spinner } from "@fluentui/react-components";
-import { ColDef } from "ag-grid-community";
+import { ColDef, RowStyleModule } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { BusinessRuleMeta } from "../model/businessRule";
@@ -84,7 +84,14 @@ export const BusinessRules = observer((props: BusinessRulesProps): React.JSX.Ele
 
   const colDefs = React.useMemo<ColDef<BusinessRuleMeta>[]>(
     () => [
-      { headerName: "Name", field: "ruleName", flex: 2, sort: "asc" },
+      {
+        headerName: "Name",
+        field: "ruleName",
+        flex: 2,
+        sort: "asc",
+        valueGetter: (params) =>
+          secondaryConnection && !params.data?.hasPrimaryConnection ? "" : (params.data?.ruleName ?? ""),
+      },
       ...(secondaryConnection
         ? [
             {
@@ -124,6 +131,7 @@ export const BusinessRules = observer((props: BusinessRulesProps): React.JSX.Ele
     <div style={{ width: "98vw", height: "85vh", alignSelf: "center" }}>
       <AgGridReact<BusinessRuleMeta>
         theme={agGridTheme}
+        modules={[RowStyleModule]}
         rowData={filteredRules}
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}

--- a/src/components/BusinessRules.tsx
+++ b/src/components/BusinessRules.tsx
@@ -7,9 +7,11 @@ import { ColDef } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { BusinessRuleMeta } from "../model/businessRule";
+import { createConnectionRowClassRules, mergeConnectionComparisonRecords } from "../utils/connectionComparison";
 
 interface BusinessRulesProps {
   connection: ToolBoxAPI.DataverseConnection | null;
+  secondaryConnection: ToolBoxAPI.DataverseConnection | null;
   dvService: dvService;
   isLoading: boolean;
   selectedTable: TableMeta;
@@ -19,7 +21,8 @@ interface BusinessRulesProps {
 }
 
 export const BusinessRules = observer((props: BusinessRulesProps): React.JSX.Element => {
-  const { connection, dvService, onLog, selectedTable, showNotification, businessRuleAttributes } = props;
+  const { connection, secondaryConnection, dvService, onLog, selectedTable, showNotification, businessRuleAttributes } =
+    props;
   const [loadingMeta, setLoadingMeta] = React.useState(false);
 
   const filteredRules = React.useMemo(() => {
@@ -41,21 +44,30 @@ export const BusinessRules = observer((props: BusinessRulesProps): React.JSX.Ele
   }, [selectedTable]);
 
   async function getBusinessRules() {
-    if (!connection) {
+    const canLoadPrimary = Boolean(connection && selectedTable.hasPrimaryConnection);
+    const canLoadSecondary = Boolean(secondaryConnection && selectedTable.hasSecondaryConnection);
+
+    if (!canLoadPrimary && !canLoadSecondary) {
       await showNotification("No Connection", "Please connect to a Dataverse environment", "warning");
       return;
     }
 
     setLoadingMeta(true);
-    await dvService
-      .getBusinessRulesForTable(selectedTable)
-      .then((rules) => {
-        selectedTable.businessRules = rules;
-        onLog(`Loaded ${rules.length} business rules for table: ${selectedTable.tableName}`, "success");
-      })
-      .catch((error: { message: any }) => {
-        onLog(`Error loading business rules for table ${selectedTable.tableName}: ${error.message}`, "error");
-      });
+    const [primaryRules, secondaryRules] = await Promise.all([
+      canLoadPrimary ? dvService.getBusinessRulesForTable(selectedTable, "primary") : Promise.resolve([]),
+      canLoadSecondary ? dvService.getBusinessRulesForTable(selectedTable, "secondary") : Promise.resolve([]),
+    ]);
+
+    selectedTable.businessRules = mergeConnectionComparisonRecords(
+      primaryRules,
+      secondaryRules,
+      (rule) => rule.ruleName,
+      (rule) => rule.ruleName,
+    );
+    onLog(
+      `Loaded ${selectedTable.businessRules.length} business rules for table: ${selectedTable.tableName}`,
+      "success",
+    );
     setLoadingMeta(false);
   }
 
@@ -73,6 +85,16 @@ export const BusinessRules = observer((props: BusinessRulesProps): React.JSX.Ele
   const colDefs = React.useMemo<ColDef<BusinessRuleMeta>[]>(
     () => [
       { headerName: "Name", field: "ruleName", flex: 2, sort: "asc" },
+      ...(secondaryConnection
+        ? [
+            {
+              headerName: secondaryConnection.name ? `2nd Name (${secondaryConnection.name})` : "2nd Name",
+              field: "secondaryDisplayName",
+              valueGetter: (params) =>
+                params.data?.hasSecondaryConnection ? params.data.secondaryDisplayName || "" : "",
+            } as ColDef<BusinessRuleMeta>,
+          ]
+        : []),
       { headerName: "Type", field: "type" },
       ...businessRuleAttributes.map(
         (attrName) =>
@@ -85,7 +107,12 @@ export const BusinessRules = observer((props: BusinessRulesProps): React.JSX.Ele
           }) as ColDef<BusinessRuleMeta>,
       ),
     ],
-    [businessRuleAttributes],
+    [businessRuleAttributes, secondaryConnection],
+  );
+
+  const rowClassRules = React.useMemo(
+    () => createConnectionRowClassRules<BusinessRuleMeta>(Boolean(secondaryConnection)),
+    [secondaryConnection],
   );
 
   const getRuleRowId = React.useCallback((rule: BusinessRuleMeta) => {
@@ -101,6 +128,7 @@ export const BusinessRules = observer((props: BusinessRulesProps): React.JSX.Ele
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}
         domLayout="normal"
+        rowClassRules={rowClassRules}
         getRowId={(params) => (params.data ? getRuleRowId(params.data) : "")}
         enableCellTextSelection={true}
       />

--- a/src/components/BusinessRules.tsx
+++ b/src/components/BusinessRules.tsx
@@ -63,6 +63,7 @@ export const BusinessRules = observer((props: BusinessRulesProps): React.JSX.Ele
       secondaryRules,
       (rule) => rule.ruleName,
       (rule) => rule.ruleName,
+      ["ruleName"],
     );
     onLog(
       `Loaded ${selectedTable.businessRules.length} business rules for table: ${selectedTable.tableName}`,

--- a/src/components/Keys.tsx
+++ b/src/components/Keys.tsx
@@ -7,9 +7,11 @@ import { Spinner } from "@fluentui/react-components";
 import { ColDef } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
+import { createConnectionRowClassRules, mergeConnectionComparisonRecords } from "../utils/connectionComparison";
 
 interface KeysProps {
   connection: ToolBoxAPI.DataverseConnection | null;
+  secondaryConnection: ToolBoxAPI.DataverseConnection | null;
   dvService: dvService;
   isLoading: boolean;
   selectedTable: TableMeta;
@@ -18,7 +20,7 @@ interface KeysProps {
 }
 
 export const Keys = observer((props: KeysProps): React.JSX.Element => {
-  const { connection, dvService, onLog, selectedTable, showNotification } = props;
+  const { connection, secondaryConnection, dvService, onLog, selectedTable, showNotification } = props;
   const [loadingMeta, setLoadingMeta] = React.useState(false);
 
   React.useEffect(() => {
@@ -30,7 +32,10 @@ export const Keys = observer((props: KeysProps): React.JSX.Element => {
   }, [selectedTable]);
 
   async function getKeysMeta() {
-    if (!connection) {
+    const canLoadPrimary = Boolean(connection && selectedTable.hasPrimaryConnection);
+    const canLoadSecondary = Boolean(secondaryConnection && selectedTable.hasSecondaryConnection);
+
+    if (!canLoadPrimary && !canLoadSecondary) {
       await showNotification("No Connection", "Please connect to a Dataverse environment", "warning");
       return;
     }
@@ -38,16 +43,18 @@ export const Keys = observer((props: KeysProps): React.JSX.Element => {
     console.log("Fetching keys metadata for table: ", selectedTable.tableName);
 
     setLoadingMeta(true);
-    await dvService
-      .getKeysMeta(selectedTable)
-      .then((keys) => {
-        console.log("Keys metadata loaded: ", keys);
-        selectedTable.keys = keys;
-        onLog(`Loaded ${keys.length} keys for table: ${selectedTable.tableName}`, "success");
-      })
-      .catch((error: { message: any }) => {
-        onLog(`Error loading keys for table ${selectedTable.tableName}: ${error.message}`, "error");
-      });
+    const [primaryKeys, secondaryKeys] = await Promise.all([
+      canLoadPrimary ? dvService.getKeysMeta(selectedTable, "primary") : Promise.resolve([]),
+      canLoadSecondary ? dvService.getKeysMeta(selectedTable, "secondary") : Promise.resolve([]),
+    ]);
+
+    selectedTable.keys = mergeConnectionComparisonRecords(
+      primaryKeys,
+      secondaryKeys,
+      (keyMeta) => keyMeta.keyName,
+      (keyMeta) => keyMeta.keyName,
+    );
+    onLog(`Loaded ${selectedTable.keys.length} keys for table: ${selectedTable.tableName}`, "success");
     setLoadingMeta(false);
     return;
   }
@@ -80,9 +87,27 @@ export const Keys = observer((props: KeysProps): React.JSX.Element => {
   }, [selectedTable.keys.length]);
 
   const colDefs = React.useMemo<ColDef<KeyMeta>[]>(
-    () => [{ headerName: "Key Name", field: "keyName", flex: 2, sort: "asc" }, ...createKeyAttr],
+    () => [
+      { headerName: "Key Name", field: "keyName", flex: 2, sort: "asc" },
+      ...(secondaryConnection
+        ? [
+            {
+              headerName: secondaryConnection.name ? `2nd Key Name (${secondaryConnection.name})` : "2nd Key Name",
+              field: "secondaryDisplayName",
+              valueGetter: (params) =>
+                params.data?.hasSecondaryConnection ? params.data.secondaryDisplayName || "" : "",
+            } as ColDef<KeyMeta>,
+          ]
+        : []),
+      ...createKeyAttr,
+    ],
 
-    [createKeyAttr],
+    [createKeyAttr, secondaryConnection],
+  );
+
+  const rowClassRules = React.useMemo(
+    () => createConnectionRowClassRules<KeyMeta>(Boolean(secondaryConnection)),
+    [secondaryConnection],
   );
 
   const keyColumnGrid = (
@@ -93,6 +118,7 @@ export const Keys = observer((props: KeysProps): React.JSX.Element => {
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}
         domLayout="normal"
+        rowClassRules={rowClassRules}
         getRowId={(params) => params.data?.keyName ?? ""}
         enableCellTextSelection={true}
       />

--- a/src/components/Keys.tsx
+++ b/src/components/Keys.tsx
@@ -53,6 +53,7 @@ export const Keys = observer((props: KeysProps): React.JSX.Element => {
       secondaryKeys,
       (keyMeta) => keyMeta.keyName,
       (keyMeta) => keyMeta.keyName,
+      ["keyName"],
     );
     onLog(`Loaded ${selectedTable.keys.length} keys for table: ${selectedTable.tableName}`, "success");
     setLoadingMeta(false);

--- a/src/components/Keys.tsx
+++ b/src/components/Keys.tsx
@@ -4,7 +4,7 @@ import { dvService } from "../utils/dataverse";
 import { KeyMeta, TableMeta } from "../model/tableMeta";
 import { Spinner } from "@fluentui/react-components";
 
-import { ColDef } from "ag-grid-community";
+import { ColDef, RowStyleModule } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { createConnectionRowClassRules, mergeConnectionComparisonRecords } from "../utils/connectionComparison";
@@ -88,7 +88,14 @@ export const Keys = observer((props: KeysProps): React.JSX.Element => {
 
   const colDefs = React.useMemo<ColDef<KeyMeta>[]>(
     () => [
-      { headerName: "Key Name", field: "keyName", flex: 2, sort: "asc" },
+      {
+        headerName: "Key Name",
+        field: "keyName",
+        flex: 2,
+        sort: "asc",
+        valueGetter: (params) =>
+          secondaryConnection && !params.data?.hasPrimaryConnection ? "" : (params.data?.keyName ?? ""),
+      },
       ...(secondaryConnection
         ? [
             {
@@ -114,6 +121,7 @@ export const Keys = observer((props: KeysProps): React.JSX.Element => {
     <div style={{ width: "98vw", height: "85vh", alignSelf: "center" }}>
       <AgGridReact<KeyMeta>
         theme={agGridTheme}
+        modules={[RowStyleModule]}
         rowData={selectedTable.keys}
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}

--- a/src/components/MetadataBrowser.tsx
+++ b/src/components/MetadataBrowser.tsx
@@ -108,6 +108,7 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
       secondaryTables,
       (table) => table.tableName,
       (table) => table.primaryDisplayName,
+      ["primaryDisplayName"],
     );
   }, []);
 
@@ -493,7 +494,6 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
         field: "primaryDisplayName",
         flex: 2,
         sort: "asc",
-        //valueGetter: (params) => (params.data?.hasPrimaryConnection ? params.data.primaryDisplayName : ""),
       },
       ...(secondaryConnection
         ? [

--- a/src/components/MetadataBrowser.tsx
+++ b/src/components/MetadataBrowser.tsx
@@ -39,7 +39,7 @@ import { ViewModel } from "../model/ViewModel";
 import { dvService as DataverseService } from "../utils/dataverse";
 import { TableMeta } from "../model/tableMeta";
 import { TableDetails } from "./TableDetail";
-import { ColumnEditRegular, OpenRegular, TextboxMoreRegular } from "@fluentui/react-icons";
+import { ColumnEditRegular, DismissRegular, OpenRegular, TextboxMoreRegular } from "@fluentui/react-icons";
 import { ExportPopover } from "./ExportPopover";
 import { TableColumnDrawer } from "./TableColumnDrawer";
 import { SolutionSelectorDrawer } from "./SolutionSelectorDrawer";
@@ -378,6 +378,16 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
     [vm, onLog],
   );
 
+  const closeTab = useCallback(
+    (tableName: string) => {
+      vm.selectedTables = (vm.selectedTables ?? []).filter((t) => t.tableName !== tableName);
+      if (selectedTab === tableName) {
+        setSelectedTab("tables");
+      }
+    },
+    [vm, selectedTab],
+  );
+
   const tableTabs =
     vm.selectedTables && vm.selectedTables.length > 0 ? (
       (vm.selectedTables ?? []).map((t) => (
@@ -390,6 +400,18 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
               iconFontSize: 12,
               stopPropagation: true,
             })}
+            <Tooltip content={`Close ${t.primaryDisplayName} tab`} relationship="label">
+              <Button
+                aria-label={`Close ${t.primaryDisplayName} tab`}
+                icon={<DismissRegular fontSize={12} />}
+                size="small"
+                appearance="subtle"
+                onClick={(e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  closeTab(t.tableName);
+                }}
+              />
+            </Tooltip>
           </span>
         </Tab>
       ))

--- a/src/components/MetadataBrowser.tsx
+++ b/src/components/MetadataBrowser.tsx
@@ -1,9 +1,14 @@
 import React, { useCallback } from "react";
 import { observer } from "mobx-react";
-import { ColDef, RowSelectionOptions, SelectionChangedEvent } from "ag-grid-community";
+import {
+  ColDef,
+  RowSelectionOptions,
+  SelectionChangedEvent,
+  RowStyleModule,
+  ValidationModule,
+} from "ag-grid-community";
 import { AgGridReact, CustomCellRendererProps } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
-
 import {
   Button,
   InputOnChangeData,
@@ -31,13 +36,14 @@ import {
 } from "@fluentui/react-components";
 
 import { ViewModel } from "../model/ViewModel";
-import { dvService } from "../utils/dataverse";
+import { dvService as DataverseService } from "../utils/dataverse";
 import { TableMeta } from "../model/tableMeta";
 import { TableDetails } from "./TableDetail";
 import { ColumnEditRegular, OpenRegular, TextboxMoreRegular } from "@fluentui/react-icons";
 import { ExportPopover } from "./ExportPopover";
 import { TableColumnDrawer } from "./TableColumnDrawer";
 import { SolutionSelectorDrawer } from "./SolutionSelectorDrawer";
+import { createConnectionRowClassRules, mergeConnectionComparisonRecords } from "../utils/connectionComparison";
 
 const useStyles = makeStyles({
   root: { backgroundColor: tokens.colorNeutralBackground1 },
@@ -45,15 +51,16 @@ const useStyles = makeStyles({
 });
 
 interface MetadataBrowserProps {
-  connection: ToolBoxAPI.DataverseConnection | null;
-  dvService: dvService;
+  primaryConnection: ToolBoxAPI.DataverseConnection | null;
+  secondaryConnection: ToolBoxAPI.DataverseConnection | null;
+  dvService: DataverseService;
   isLoading: boolean;
   vm: ViewModel;
   onLog: (message: string, type?: "info" | "success" | "warning" | "error") => void;
 }
 
 export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX.Element => {
-  const { connection, dvService, onLog, vm } = props;
+  const { primaryConnection, secondaryConnection, dvService, onLog, vm } = props;
   const selectSolutionLabel = "Select a solution to load tables";
   const openTableSourceOptionsLabel = "Open table source options";
   const openExportDialogLabel = "Open export dialog";
@@ -77,7 +84,8 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
     } else
       return vm.tableMetadata.filter(
         (t) =>
-          t.displayName.toLowerCase().includes(tableQuery.toLowerCase()) ||
+          t.primaryDisplayName.toLowerCase().includes(tableQuery.toLowerCase()) ||
+          t.secondaryDisplayName?.toLowerCase().includes(tableQuery.toLowerCase()) ||
           t.tableName.toLowerCase().includes(tableQuery.toLowerCase()),
       );
   }, [tableQuery, vm.tableMetadata]);
@@ -94,9 +102,76 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
     [],
   );
 
+  const mergeTableMetadata = useCallback((primaryTables: TableMeta[], secondaryTables: TableMeta[]): TableMeta[] => {
+    return mergeConnectionComparisonRecords(
+      primaryTables,
+      secondaryTables,
+      (table) => table.tableName,
+      (table) => table.primaryDisplayName,
+    );
+  }, []);
+
+  const getMergedAllTables = useCallback(async (): Promise<TableMeta[]> => {
+    const canLoadPrimary = Boolean(primaryConnection);
+    const canLoadSecondary = Boolean(secondaryConnection);
+
+    if (!canLoadPrimary && !canLoadSecondary) {
+      throw new Error("No connection available");
+    }
+
+    const [primaryTables, secondaryTables] = await Promise.all([
+      canLoadPrimary ? dvService.getAllTables(true) : Promise.resolve([]),
+      canLoadSecondary ? dvService.getAllTables(false) : Promise.resolve([]),
+    ]);
+
+    return mergeTableMetadata(primaryTables, secondaryTables);
+  }, [dvService, mergeTableMetadata, primaryConnection, secondaryConnection]);
+
+  const getMergedSolutionTables = useCallback(async (): Promise<TableMeta[]> => {
+    if (!vm.selectedSolution) {
+      return [];
+    }
+
+    const canLoadPrimary = Boolean(primaryConnection);
+    const canLoadSecondary = Boolean(secondaryConnection);
+
+    if (!canLoadPrimary && !canLoadSecondary) {
+      throw new Error("No connection available");
+    }
+
+    if (canLoadPrimary) {
+      const primaryTables = await dvService.getSolutionTables(vm.selectedSolution.uniqueName, "primary");
+
+      if (!canLoadSecondary) {
+        return mergeTableMetadata(primaryTables, []);
+      }
+
+      const secondaryLookups = await Promise.all(
+        primaryTables.map((primaryTable) => dvService.getTableByLogicalName(primaryTable.tableName, "secondary")),
+      );
+      const secondaryTables = secondaryLookups.filter((table): table is TableMeta => Boolean(table));
+
+      return mergeTableMetadata(primaryTables, secondaryTables);
+    }
+
+    const secondaryTables = canLoadSecondary
+      ? await dvService
+          .getSolutionTables(vm.selectedSolution.uniqueName, "secondary")
+          .catch((error: { message?: string }) => {
+            onLog(
+              `Unable to load solution tables from secondary connection for ${vm.selectedSolution?.solutionName}: ${error.message ?? "Unknown error"}`,
+              "warning",
+            );
+            return [];
+          })
+      : [];
+
+    return mergeTableMetadata([], secondaryTables);
+  }, [dvService, mergeTableMetadata, onLog, primaryConnection, secondaryConnection, vm.selectedSolution]);
+
   const openTableInConnectionBrowser = useCallback(
     async (table: TableMeta) => {
-      if (!connection) {
+      if (!primaryConnection) {
         onLog("Cannot open table: no active connection available.", "warning");
         await showNotification("No active connection", "Please connect before opening a table.", "warning");
         return;
@@ -118,7 +193,7 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
         onLog(`Failed to open table ${table.tableName}: ${message}`, "error");
       }
     },
-    [connection, onLog, showNotification],
+    [primaryConnection, onLog, showNotification],
   );
 
   const renderOpenTableButton = useCallback(
@@ -131,9 +206,9 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
         stopPropagation?: boolean;
       },
     ) => (
-      <Tooltip content={`Open ${table.displayName} definition in browser`} relationship="label">
+      <Tooltip content={`Open ${table.primaryDisplayName} definition in browser`} relationship="label">
         <Button
-          aria-label={`Open ${table.displayName} definition in browser`}
+          aria-label={`Open ${table.primaryDisplayName} definition in browser`}
           icon={<OpenRegular fontSize={options?.iconFontSize} />}
           size={options?.size ?? "small"}
           appearance={options?.appearance ?? "secondary"}
@@ -155,13 +230,13 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
         .getSolutions(managed)
         .then((solutions) => {
           vm.solutions = solutions;
-          onLog(`Loaded ${solutions.length} solutions from ${connection?.name}`, "success");
+          onLog(`Loaded ${solutions.length} solutions from ${primaryConnection?.name}`, "success");
         })
         .catch((error: { message: any }) => {
           onLog(`Error loading solutions: ${error.message}`, "error");
         });
     }
-  }, [isSolutionSelOpen, managed]);
+  }, [isSolutionSelOpen, managed, primaryConnection]);
 
   async function getAllTableMeta() {
     vm.selectedSolution = undefined;
@@ -170,12 +245,13 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
   async function getTableMeta() {
     setLoadingMeta(true);
     if (vm.selectedSolution) {
-      await dvService
-        .getSolutionTables(vm.selectedSolution.uniqueName)
+      await getMergedSolutionTables()
         .then((tables) => {
           vm.tableMetadata = tables;
-          console.log(tables);
-          onLog(`Loaded ${tables.length} tables from solution: ${vm.selectedSolution?.solutionName}`, "success");
+          onLog(
+            `Loaded ${tables.length} tables from solution: ${vm.selectedSolution?.solutionName} (${primaryConnection?.name}${secondaryConnection ? ` and ${secondaryConnection.name}` : ""})`,
+            "success",
+          );
         })
         .catch((error: { message: any }) => {
           onLog(`Error loading tables from solution: ${error.message}`, "error");
@@ -184,11 +260,13 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
           setLoadingMeta(false);
         });
     } else {
-      await dvService
-        .getAllTables()
+      await getMergedAllTables()
         .then((tables) => {
           vm.tableMetadata = tables;
-          onLog(`Loaded ${tables.length} tables from ${connection?.name}`, "success");
+          onLog(
+            `Loaded ${tables.length} tables from ${primaryConnection?.name}${secondaryConnection ? ` and ${secondaryConnection.name}` : ""}`,
+            "success",
+          );
         })
         .catch((error: { message: any }) => {
           onLog(`Error loading tables: ${error.message}`, "error");
@@ -241,7 +319,7 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
 
     const headers = ["Table Name", "Logical Name", ...vm.tableAttributes.map((attr) => attr)];
     const rows = data.map((table) => [
-      table.displayName,
+      table.primaryDisplayName,
       table.tableName,
       ...vm.tableAttributes.map((attr) => table.attributes.find((a) => a.attributeName === attr)?.attributeValue || ""),
     ]);
@@ -293,7 +371,7 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
       const exists = vm.selectedTables.some((t) => t.tableName === item.tableName);
       if (!exists) {
         vm.selectedTables.push(item);
-        onLog(`Added "${item.displayName}" to selected tables.`, "success");
+        onLog(`Added "${item.primaryDisplayName}" to selected tables.`, "success");
       }
       setSelectedTab(item.tableName as TabValue);
     },
@@ -305,7 +383,7 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
       (vm.selectedTables ?? []).map((t) => (
         <Tab key={t.tableName} id={`Table-${t.tableName}`} value={t.tableName as TabValue}>
           <span className={styles.tabLabel}>
-            <span>{t.displayName}</span>
+            <span>{t.primaryDisplayName}</span>
             {renderOpenTableButton(t, {
               appearance: "subtle",
               size: "small",
@@ -322,7 +400,8 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
   const tableDetails = vm.selectedTables?.map((t) => (
     <div key={t.tableName} role="tabpanel" aria-labelledby={`Table-${t.tableName}`}>
       <TableDetails
-        connection={connection}
+        primaryConnection={primaryConnection}
+        secondaryConnection={secondaryConnection}
         dvService={dvService}
         isLoading={loadingMeta}
         viewModel={vm}
@@ -355,7 +434,7 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
         maxWidth: 60,
         minWidth: 60,
         cellRenderer: (params: CustomCellRendererProps<TableMeta>) => {
-          const label = `Open details tab for ${params.data?.displayName ?? "table"}`;
+          const label = `Open details tab for ${params.data?.primaryDisplayName ?? "table"}`;
           return (
             <Tooltip content={label} relationship="label">
               <Button
@@ -387,11 +466,24 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
         },
       },
       {
-        headerName: "Table Name",
-        field: "displayName",
+        headerName:
+          secondaryConnection && primaryConnection?.name ? `Table Name (${primaryConnection.name})` : "Table Name",
+        field: "primaryDisplayName",
         flex: 2,
         sort: "asc",
+        //valueGetter: (params) => (params.data?.hasPrimaryConnection ? params.data.primaryDisplayName : ""),
       },
+      ...(secondaryConnection
+        ? [
+            {
+              headerName: secondaryConnection.name ? `2nd Table Name (${secondaryConnection.name})` : "2nd Table Name",
+              field: "secondaryDisplayName",
+              flex: 2,
+              valueGetter: (params) =>
+                params.data?.hasSecondaryConnection ? params.data.secondaryDisplayName || "" : "",
+            } satisfies ColDef<TableMeta>,
+          ]
+        : []),
       {
         headerName: "Logical Name",
         field: "tableName",
@@ -409,7 +501,7 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
             }) as ColDef<TableMeta>,
         ),
     ],
-    [renderOpenTableButton, vm.tableAttributes],
+    [primaryConnection, renderOpenTableButton, secondaryConnection, vm.tableAttributes],
   );
 
   const rowSelection = React.useMemo<RowSelectionOptions | "single" | "multiple">(() => {
@@ -417,6 +509,11 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
       mode: "multiRow",
     };
   }, []);
+
+  const rowClassRules = React.useMemo(
+    () => createConnectionRowClassRules<TableMeta>(Boolean(secondaryConnection)),
+    [secondaryConnection],
+  );
 
   function tableSelected(event: SelectionChangedEvent<TableMeta>): void {
     const selectedRows = event.api.getSelectedRows();
@@ -429,9 +526,11 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
     <div style={{ width: "98vw", height: "93vh" }}>
       <AgGridReact<TableMeta>
         theme={agGridTheme}
+        modules={[RowStyleModule, ValidationModule]}
         rowData={filterdTableMetadata}
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}
+        rowClassRules={rowClassRules}
         domLayout="normal"
         rowSelection={rowSelection}
         onSelectionChanged={tableSelected}
@@ -581,7 +680,7 @@ export const MetadataBrowser = observer((props: MetadataBrowserProps): React.JSX
         <div>
           {isExportPopoverOpen && (
             <ExportPopover
-              connection={connection}
+              connection={primaryConnection}
               dvSvc={dvService}
               vm={vm}
               isExportOpen={isExportPopoverOpen}

--- a/src/components/Privileges.tsx
+++ b/src/components/Privileges.tsx
@@ -7,9 +7,11 @@ import { Spinner } from "@fluentui/react-components";
 import { ColDef } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
+import { createConnectionRowClassRules, mergeConnectionComparisonRecords } from "../utils/connectionComparison";
 
 interface PrivilegesProps {
   connection: ToolBoxAPI.DataverseConnection | null;
+  secondaryConnection: ToolBoxAPI.DataverseConnection | null;
   dvService: dvService;
   isLoading: boolean;
   selectedTable: TableMeta;
@@ -18,7 +20,7 @@ interface PrivilegesProps {
 }
 
 export const Privileges = observer((props: PrivilegesProps): React.JSX.Element => {
-  const { connection, dvService, onLog, selectedTable, showNotification } = props;
+  const { connection, secondaryConnection, dvService, onLog, selectedTable, showNotification } = props;
   const [loadingMeta, setLoadingMeta] = React.useState(false);
 
   React.useEffect(() => {
@@ -30,7 +32,10 @@ export const Privileges = observer((props: PrivilegesProps): React.JSX.Element =
   }, [selectedTable]);
 
   async function getPrivileges() {
-    if (!connection) {
+    const canLoadPrimary = Boolean(connection && selectedTable.hasPrimaryConnection);
+    const canLoadSecondary = Boolean(secondaryConnection && selectedTable.hasSecondaryConnection);
+
+    if (!canLoadPrimary && !canLoadSecondary) {
       await showNotification("No Connection", "Please connect to a Dataverse environment", "warning");
       return;
     }
@@ -38,16 +43,18 @@ export const Privileges = observer((props: PrivilegesProps): React.JSX.Element =
     console.log("Fetching privileges metadata for table: ", selectedTable.tableName);
 
     setLoadingMeta(true);
-    await dvService
-      .getPrivilegesMetadata(selectedTable)
-      .then((privileges) => {
-        console.log("Privileges metadata loaded: ", privileges);
-        selectedTable.privileges = privileges;
-        onLog(`Loaded ${privileges.length} privileges for table: ${selectedTable.tableName}`, "success");
-      })
-      .catch((error: { message: any }) => {
-        onLog(`Error loading privileges for table ${selectedTable.tableName}: ${error.message}`, "error");
-      });
+    const [primaryPrivileges, secondaryPrivileges] = await Promise.all([
+      canLoadPrimary ? dvService.getPrivilegesMetadata(selectedTable, "primary") : Promise.resolve([]),
+      canLoadSecondary ? dvService.getPrivilegesMetadata(selectedTable, "secondary") : Promise.resolve([]),
+    ]);
+
+    selectedTable.privileges = mergeConnectionComparisonRecords(
+      primaryPrivileges,
+      secondaryPrivileges,
+      (privilege) => privilege.privilegeName,
+      (privilege) => privilege.privilegeName,
+    );
+    onLog(`Loaded ${selectedTable.privileges.length} privileges for table: ${selectedTable.tableName}`, "success");
     setLoadingMeta(false);
     return;
   }
@@ -80,9 +87,29 @@ export const Privileges = observer((props: PrivilegesProps): React.JSX.Element =
   }, [selectedTable.privileges.length]);
 
   const colDefs = React.useMemo<ColDef<PrivilegeMeta>[]>(
-    () => [{ headerName: "Privilege Name", field: "privilegeName", flex: 2, sort: "asc" }, ...createPrivilegeAttr],
+    () => [
+      { headerName: "Privilege Name", field: "privilegeName", flex: 2, sort: "asc" },
+      ...(secondaryConnection
+        ? [
+            {
+              headerName: secondaryConnection.name
+                ? `2nd Privilege Name (${secondaryConnection.name})`
+                : "2nd Privilege Name",
+              field: "secondaryDisplayName",
+              valueGetter: (params) =>
+                params.data?.hasSecondaryConnection ? params.data.secondaryDisplayName || "" : "",
+            } as ColDef<PrivilegeMeta>,
+          ]
+        : []),
+      ...createPrivilegeAttr,
+    ],
 
-    [createPrivilegeAttr],
+    [createPrivilegeAttr, secondaryConnection],
+  );
+
+  const rowClassRules = React.useMemo(
+    () => createConnectionRowClassRules<PrivilegeMeta>(Boolean(secondaryConnection)),
+    [secondaryConnection],
   );
 
   const privilegesGrid = (
@@ -93,6 +120,7 @@ export const Privileges = observer((props: PrivilegesProps): React.JSX.Element =
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}
         domLayout="normal"
+        rowClassRules={rowClassRules}
         getRowId={(params) => params.data?.privilegeName ?? ""}
         enableCellTextSelection={true}
       />

--- a/src/components/Privileges.tsx
+++ b/src/components/Privileges.tsx
@@ -4,7 +4,7 @@ import { dvService } from "../utils/dataverse";
 import { PrivilegeMeta, TableMeta } from "../model/tableMeta";
 import { Spinner } from "@fluentui/react-components";
 
-import { ColDef } from "ag-grid-community";
+import { ColDef, RowStyleModule } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { createConnectionRowClassRules, mergeConnectionComparisonRecords } from "../utils/connectionComparison";
@@ -88,7 +88,14 @@ export const Privileges = observer((props: PrivilegesProps): React.JSX.Element =
 
   const colDefs = React.useMemo<ColDef<PrivilegeMeta>[]>(
     () => [
-      { headerName: "Privilege Name", field: "privilegeName", flex: 2, sort: "asc" },
+      {
+        headerName: "Privilege Name",
+        field: "privilegeName",
+        flex: 2,
+        sort: "asc",
+        valueGetter: (params) =>
+          secondaryConnection && !params.data?.hasPrimaryConnection ? "" : (params.data?.privilegeName ?? ""),
+      },
       ...(secondaryConnection
         ? [
             {
@@ -116,6 +123,7 @@ export const Privileges = observer((props: PrivilegesProps): React.JSX.Element =
     <div style={{ width: "98vw", height: "85vh", alignSelf: "center" }}>
       <AgGridReact<PrivilegeMeta>
         theme={agGridTheme}
+        modules={[RowStyleModule]}
         rowData={selectedTable.privileges}
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}

--- a/src/components/Privileges.tsx
+++ b/src/components/Privileges.tsx
@@ -53,6 +53,7 @@ export const Privileges = observer((props: PrivilegesProps): React.JSX.Element =
       secondaryPrivileges,
       (privilege) => privilege.privilegeName,
       (privilege) => privilege.privilegeName,
+      ["privilegeName"],
     );
     onLog(`Loaded ${selectedTable.privileges.length} privileges for table: ${selectedTable.tableName}`, "success");
     setLoadingMeta(false);

--- a/src/components/Relationships.tsx
+++ b/src/components/Relationships.tsx
@@ -8,10 +8,12 @@ import { ColDef, SelectionChangedEvent, RowSelectionOptions } from "ag-grid-comm
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { ViewModel } from "../model/ViewModel";
+import { createConnectionRowClassRules, mergeConnectionComparisonRecords } from "../utils/connectionComparison";
 
 interface RelationshipsProps {
   viewModel: ViewModel;
   connection: ToolBoxAPI.DataverseConnection | null;
+  secondaryConnection: ToolBoxAPI.DataverseConnection | null;
   dvService: dvService;
   isLoading: boolean;
   selectedTable: TableMeta;
@@ -21,7 +23,7 @@ interface RelationshipsProps {
 }
 
 export const Relationships = observer((props: RelationshipsProps): React.JSX.Element => {
-  const { connection, dvService, onLog, selectedTable, showNotification, type, viewModel } = props;
+  const { connection, secondaryConnection, dvService, onLog, selectedTable, showNotification, type, viewModel } = props;
   const [loadingMeta, setLoadingMeta] = React.useState(false);
 
   React.useEffect(() => {
@@ -32,7 +34,10 @@ export const Relationships = observer((props: RelationshipsProps): React.JSX.Ele
   }, [selectedTable]);
 
   async function getRelationshipMeta() {
-    if (!connection) {
+    const canLoadPrimary = Boolean(connection && selectedTable.hasPrimaryConnection);
+    const canLoadSecondary = Boolean(secondaryConnection && selectedTable.hasSecondaryConnection);
+
+    if (!canLoadPrimary && !canLoadSecondary) {
       await showNotification("No Connection", "Please connect to a Dataverse environment", "warning");
       return;
     }
@@ -40,16 +45,21 @@ export const Relationships = observer((props: RelationshipsProps): React.JSX.Ele
     //console.log("Fetching Relationships metadata for table: ", selectedTable.tableName);
 
     setLoadingMeta(true);
-    await dvService
-      .getRelationshipsMeta(selectedTable, type)
-      .then((relationships) => {
-        console.log("Relationships metadata loaded: ", relationships);
-        selectedTable.relationships.push(...relationships);
-        onLog(`Loaded ${relationships.length} relationships for table: ${selectedTable.tableName}`, "success");
-      })
-      .catch((error: { message: any }) => {
-        onLog(`Error loading relationships for table ${selectedTable.tableName}: ${error.message}`, "error");
-      });
+    const [primaryRelationships, secondaryRelationships] = await Promise.all([
+      canLoadPrimary ? dvService.getRelationshipsMeta(selectedTable, type, "primary") : Promise.resolve([]),
+      canLoadSecondary ? dvService.getRelationshipsMeta(selectedTable, type, "secondary") : Promise.resolve([]),
+    ]);
+
+    selectedTable.relationships = mergeConnectionComparisonRecords(
+      primaryRelationships,
+      secondaryRelationships,
+      (relationship) => relationship.relationshipName,
+      (relationship) => relationship.relationshipName,
+    );
+    onLog(
+      `Loaded ${selectedTable.relationships.length} relationships for table: ${selectedTable.tableName}`,
+      "success",
+    );
     setLoadingMeta(false);
     return;
   }
@@ -98,8 +108,28 @@ export const Relationships = observer((props: RelationshipsProps): React.JSX.Ele
   }, [selectedTable.relationships.length, type, viewModel.relationshipAttributes]);
 
   const colDefs = React.useMemo<ColDef<RelationshipMeta>[]>(
-    () => [{ headerName: "Relationship Name", field: "relationshipName", flex: 2, sort: "asc" }, ...createRelAttribs],
-    [createRelAttribs],
+    () => [
+      { headerName: "Relationship Name", field: "relationshipName", flex: 2, sort: "asc" },
+      ...(secondaryConnection
+        ? [
+            {
+              headerName: secondaryConnection.name
+                ? `2nd Relationship Name (${secondaryConnection.name})`
+                : "2nd Relationship Name",
+              field: "secondaryDisplayName",
+              valueGetter: (params) =>
+                params.data?.hasSecondaryConnection ? params.data.secondaryDisplayName || "" : "",
+            } as ColDef<RelationshipMeta>,
+          ]
+        : []),
+      ...createRelAttribs,
+    ],
+    [createRelAttribs, secondaryConnection],
+  );
+
+  const rowClassRules = React.useMemo(
+    () => createConnectionRowClassRules<RelationshipMeta>(Boolean(secondaryConnection)),
+    [secondaryConnection],
   );
 
   function relsSelected(event: SelectionChangedEvent<RelationshipMeta>): void {
@@ -120,6 +150,7 @@ export const Relationships = observer((props: RelationshipsProps): React.JSX.Ele
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}
         domLayout="normal"
+        rowClassRules={rowClassRules}
         rowSelection={rowSelection}
         onSelectionChanged={relsSelected}
         getRowId={(params) => params.data?.relationshipName ?? ""}

--- a/src/components/Relationships.tsx
+++ b/src/components/Relationships.tsx
@@ -55,6 +55,7 @@ export const Relationships = observer((props: RelationshipsProps): React.JSX.Ele
       secondaryRelationships,
       (relationship) => relationship.relationshipName,
       (relationship) => relationship.relationshipName,
+      ["relationshipName"],
     );
     onLog(
       `Loaded ${selectedTable.relationships.length} relationships for table: ${selectedTable.tableName}`,

--- a/src/components/Relationships.tsx
+++ b/src/components/Relationships.tsx
@@ -4,7 +4,7 @@ import { dvService } from "../utils/dataverse";
 import { RelationshipMeta, TableMeta } from "../model/tableMeta";
 import { Spinner, TableRowId } from "@fluentui/react-components";
 
-import { ColDef, SelectionChangedEvent, RowSelectionOptions } from "ag-grid-community";
+import { ColDef, SelectionChangedEvent, RowSelectionOptions, RowStyleModule } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { ViewModel } from "../model/ViewModel";
@@ -109,7 +109,14 @@ export const Relationships = observer((props: RelationshipsProps): React.JSX.Ele
 
   const colDefs = React.useMemo<ColDef<RelationshipMeta>[]>(
     () => [
-      { headerName: "Relationship Name", field: "relationshipName", flex: 2, sort: "asc" },
+      {
+        headerName: "Relationship Name",
+        field: "relationshipName",
+        flex: 2,
+        sort: "asc",
+        valueGetter: (params) =>
+          secondaryConnection && !params.data?.hasPrimaryConnection ? "" : (params.data?.relationshipName ?? ""),
+      },
       ...(secondaryConnection
         ? [
             {
@@ -146,6 +153,7 @@ export const Relationships = observer((props: RelationshipsProps): React.JSX.Ele
     <div style={{ width: "98vw", height: "85vh", alignSelf: "center" }}>
       <AgGridReact<RelationshipMeta>
         theme={agGridTheme}
+        modules={[RowStyleModule]}
         rowData={filteredRelationships.filter((r) => r.type === type)}
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}

--- a/src/components/Solutions.tsx
+++ b/src/components/Solutions.tsx
@@ -53,6 +53,7 @@ export const Solutions = observer((props: SolutionsProps): React.JSX.Element => 
       secondarySolutions,
       (solution) => solution.uniqueName,
       (solution) => solution.solutionName,
+      ["solutionName"],
     );
     onLog(`Loaded ${selectedTable.solutions.length} solutions for table: ${selectedTable.tableName}`, "success");
     setLoadingMeta(false);

--- a/src/components/Solutions.tsx
+++ b/src/components/Solutions.tsx
@@ -7,9 +7,11 @@ import { ColDef } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { Solution } from "../model/solution";
+import { createConnectionRowClassRules, mergeConnectionComparisonRecords } from "../utils/connectionComparison";
 
 interface SolutionsProps {
   connection: ToolBoxAPI.DataverseConnection | null;
+  secondaryConnection: ToolBoxAPI.DataverseConnection | null;
   dvService: dvService;
   isLoading: boolean;
   selectedTable: TableMeta;
@@ -18,7 +20,7 @@ interface SolutionsProps {
 }
 
 export const Solutions = observer((props: SolutionsProps): React.JSX.Element => {
-  const { connection, dvService, onLog, selectedTable, showNotification } = props;
+  const { connection, secondaryConnection, dvService, onLog, selectedTable, showNotification } = props;
   const [loadingMeta, setLoadingMeta] = React.useState(false);
 
   React.useEffect(() => {
@@ -30,7 +32,10 @@ export const Solutions = observer((props: SolutionsProps): React.JSX.Element => 
   }, [selectedTable]);
 
   async function getSolutions() {
-    if (!connection) {
+    const canLoadPrimary = Boolean(connection && selectedTable.hasPrimaryConnection);
+    const canLoadSecondary = Boolean(secondaryConnection && selectedTable.hasSecondaryConnection);
+
+    if (!canLoadPrimary && !canLoadSecondary) {
       await showNotification("No Connection", "Please connect to a Dataverse environment", "warning");
       return;
     }
@@ -38,16 +43,18 @@ export const Solutions = observer((props: SolutionsProps): React.JSX.Element => 
     console.log("Fetching solutions metadata for table: ", selectedTable.tableName);
 
     setLoadingMeta(true);
-    await dvService
-      .getSolutionsForTable(selectedTable)
-      .then((solutions) => {
-        console.log("Solutions metadata loaded: ", solutions);
-        selectedTable.solutions = solutions;
-        onLog(`Loaded ${solutions.length} solutions for table: ${selectedTable.tableName}`, "success");
-      })
-      .catch((error: { message: any }) => {
-        onLog(`Error loading solutions for table ${selectedTable.tableName}: ${error.message}`, "error");
-      });
+    const [primarySolutions, secondarySolutions] = await Promise.all([
+      canLoadPrimary ? dvService.getSolutionsForTable(selectedTable, "primary") : Promise.resolve([]),
+      canLoadSecondary ? dvService.getSolutionsForTable(selectedTable, "secondary") : Promise.resolve([]),
+    ]);
+
+    selectedTable.solutions = mergeConnectionComparisonRecords(
+      primarySolutions,
+      secondarySolutions,
+      (solution) => solution.uniqueName,
+      (solution) => solution.solutionName,
+    );
+    onLog(`Loaded ${selectedTable.solutions.length} solutions for table: ${selectedTable.tableName}`, "success");
     setLoadingMeta(false);
     return;
   }
@@ -66,6 +73,16 @@ export const Solutions = observer((props: SolutionsProps): React.JSX.Element => 
   const colDefs = React.useMemo<ColDef<Solution>[]>(
     () => [
       { headerName: "Name", field: "solutionName", flex: 2, sort: "asc" },
+      ...(secondaryConnection
+        ? [
+            {
+              headerName: secondaryConnection.name ? `2nd Name (${secondaryConnection.name})` : "2nd Name",
+              field: "secondaryDisplayName",
+              valueGetter: (params) =>
+                params.data?.hasSecondaryConnection ? params.data.secondaryDisplayName || "" : "",
+            } as ColDef<Solution>,
+          ]
+        : []),
       { headerName: "Unique Name", field: "uniqueName" },
       { headerName: "Description", field: "description" },
       { headerName: "Version", field: "version" },
@@ -81,7 +98,12 @@ export const Solutions = observer((props: SolutionsProps): React.JSX.Element => 
       },
     ],
     // Column definitions with formatters - no reactive dependencies needed
-    [],
+    [secondaryConnection],
+  );
+
+  const rowClassRules = React.useMemo(
+    () => createConnectionRowClassRules<Solution>(Boolean(secondaryConnection)),
+    [secondaryConnection],
   );
 
   const solutionsGrid = (
@@ -92,6 +114,7 @@ export const Solutions = observer((props: SolutionsProps): React.JSX.Element => 
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}
         domLayout="normal"
+        rowClassRules={rowClassRules}
         getRowId={(params) => params.data?.uniqueName ?? ""}
         enableCellTextSelection={true}
       />

--- a/src/components/Solutions.tsx
+++ b/src/components/Solutions.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react";
 import { dvService } from "../utils/dataverse";
 import { TableMeta } from "../model/tableMeta";
 import { Spinner } from "@fluentui/react-components";
-import { ColDef } from "ag-grid-community";
+import { ColDef, RowStyleModule } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { Solution } from "../model/solution";
@@ -72,7 +72,14 @@ export const Solutions = observer((props: SolutionsProps): React.JSX.Element => 
 
   const colDefs = React.useMemo<ColDef<Solution>[]>(
     () => [
-      { headerName: "Name", field: "solutionName", flex: 2, sort: "asc" },
+      {
+        headerName: "Name",
+        field: "solutionName",
+        flex: 2,
+        sort: "asc",
+        valueGetter: (params) =>
+          secondaryConnection && !params.data?.hasPrimaryConnection ? "" : (params.data?.solutionName ?? ""),
+      },
       ...(secondaryConnection
         ? [
             {
@@ -110,6 +117,7 @@ export const Solutions = observer((props: SolutionsProps): React.JSX.Element => 
     <div style={{ width: "98vw", height: "85vh", alignSelf: "center" }}>
       <AgGridReact<Solution>
         theme={agGridTheme}
+        modules={[RowStyleModule]}
         rowData={selectedTable.solutions}
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}

--- a/src/components/TableColumns.tsx
+++ b/src/components/TableColumns.tsx
@@ -7,6 +7,7 @@ import { Spinner, TableRowId, Tooltip, tokens } from "@fluentui/react-components
 import { ColDef, SelectionChangedEvent, RowSelectionOptions } from "ag-grid-community";
 import { AgGridReact, CustomCellRendererProps } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
+import { createConnectionRowClassRules, mergeConnectionComparisonRecords } from "../utils/connectionComparison";
 import {
   AppsRegular,
   CalendarLtrRegular,
@@ -29,7 +30,8 @@ import {
 import { ColumnMeta } from "../model/columnMeta";
 
 interface TableColumnsProps {
-  connection: ToolBoxAPI.DataverseConnection | null;
+  primary: ToolBoxAPI.DataverseConnection | null;
+  secondary: ToolBoxAPI.DataverseConnection | null;
   dvService: dvService;
   isLoading: boolean;
   viewModel: ViewModel;
@@ -39,7 +41,7 @@ interface TableColumnsProps {
 }
 
 export const TableColumns = observer((props: TableColumnsProps): React.JSX.Element => {
-  const { connection, dvService, onLog, viewModel, table, showNotification } = props;
+  const { primary, secondary, dvService, onLog, viewModel, table, showNotification } = props;
 
   const getDataTypeIcon = React.useCallback((dataType: string): React.JSX.Element => {
     const normalizedType = dataType.trim().toLowerCase();
@@ -123,7 +125,10 @@ export const TableColumns = observer((props: TableColumnsProps): React.JSX.Eleme
   }, [selectedTable.columnSearch, selectedTable.columns]);
 
   async function getColumnsMeta() {
-    if (!connection) {
+    const canLoadPrimary = Boolean(primary && selectedTable.hasPrimaryConnection);
+    const canLoadSecondary = Boolean(secondary && selectedTable.hasSecondaryConnection);
+
+    if (!canLoadPrimary && !canLoadSecondary) {
       await showNotification("No Connection", "Please connect to a Dataverse environment", "warning");
       return;
     }
@@ -132,15 +137,18 @@ export const TableColumns = observer((props: TableColumnsProps): React.JSX.Eleme
     }
     try {
       setLoadingMeta(true);
-      await dvService
-        .getColumnsMeta(table)
-        .then((columns) => {
-          selectedTable.columns = columns;
-          onLog(`Loaded ${columns.length} columns for table: ${table}`, "success");
-        })
-        .catch((error: { message: any }) => {
-          throw new Error(error.message);
-        });
+      const [primaryColumns, secondaryColumns] = await Promise.all([
+        canLoadPrimary ? dvService.getColumnsMeta(table, "primary") : Promise.resolve([]),
+        canLoadSecondary ? dvService.getColumnsMeta(table, "secondary") : Promise.resolve([]),
+      ]);
+
+      selectedTable.columns = mergeConnectionComparisonRecords(
+        primaryColumns,
+        secondaryColumns,
+        (column) => column.columnName,
+        (column) => column.displayName,
+      );
+      onLog(`Loaded ${selectedTable.columns.length} columns for table: ${table}`, "success");
     } catch (error) {
       const errorMsg = `Error loading columns for table ${table}: ${(error as Error).message}`;
       onLog(errorMsg, "error");
@@ -172,6 +180,18 @@ export const TableColumns = observer((props: TableColumnsProps): React.JSX.Eleme
   const colDefs = React.useMemo<ColDef<ColumnMeta>[]>(
     () => [
       { headerName: "Column Name", field: "displayName", sort: "asc" },
+      ...(secondary
+        ? [
+            {
+              headerName: secondary.name
+                ? `2nd Column Name (${secondary.name})`
+                : "2nd Column Name",
+              field: "secondaryDisplayName",
+              valueGetter: (params) =>
+                params.data?.hasSecondaryConnection ? params.data.secondaryDisplayName || "" : "",
+            } satisfies ColDef<ColumnMeta>,
+          ]
+        : []),
       { headerName: "Logical Name", field: "columnName" },
       {
         headerName: "Data Type",
@@ -208,7 +228,7 @@ export const TableColumns = observer((props: TableColumnsProps): React.JSX.Eleme
             }) as ColDef<ColumnMeta>,
         ),
     ],
-    [getDataTypeIcon, viewModel.columnAttributes],
+    [getDataTypeIcon, secondary, viewModel.columnAttributes],
   );
 
   function colsSelected(event: SelectionChangedEvent<ColumnMeta>): void {
@@ -221,6 +241,7 @@ export const TableColumns = observer((props: TableColumnsProps): React.JSX.Eleme
       mode: "multiRow",
     };
   }, []);
+  const rowClassRules = React.useMemo(() => createConnectionRowClassRules<ColumnMeta>(Boolean(secondary)), [secondary]);
   const tableColumnGrid = (
     <div style={{ width: "98vw", height: "85vh", alignSelf: "center" }}>
       <AgGridReact<ColumnMeta>
@@ -230,6 +251,7 @@ export const TableColumns = observer((props: TableColumnsProps): React.JSX.Eleme
         defaultColDef={defaultColDefs}
         domLayout="normal"
         rowSelection={rowSelection}
+        rowClassRules={rowClassRules}
         onSelectionChanged={colsSelected}
         getRowId={(params) => params.data?.columnName ?? ""}
         enableCellTextSelection={true}

--- a/src/components/TableColumns.tsx
+++ b/src/components/TableColumns.tsx
@@ -147,6 +147,7 @@ export const TableColumns = observer((props: TableColumnsProps): React.JSX.Eleme
         secondaryColumns,
         (column) => column.columnName,
         (column) => column.displayName,
+        ["displayName"],
       );
       onLog(`Loaded ${selectedTable.columns.length} columns for table: ${table}`, "success");
     } catch (error) {

--- a/src/components/TableColumns.tsx
+++ b/src/components/TableColumns.tsx
@@ -4,7 +4,7 @@ import { ViewModel } from "../model/ViewModel";
 import { dvService } from "../utils/dataverse";
 import { TableMeta } from "../model/tableMeta";
 import { Spinner, TableRowId, Tooltip, tokens } from "@fluentui/react-components";
-import { ColDef, SelectionChangedEvent, RowSelectionOptions } from "ag-grid-community";
+import { ColDef, SelectionChangedEvent, RowSelectionOptions, RowStyleModule } from "ag-grid-community";
 import { AgGridReact, CustomCellRendererProps } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { createConnectionRowClassRules, mergeConnectionComparisonRecords } from "../utils/connectionComparison";
@@ -179,7 +179,13 @@ export const TableColumns = observer((props: TableColumnsProps): React.JSX.Eleme
 
   const colDefs = React.useMemo<ColDef<ColumnMeta>[]>(
     () => [
-      { headerName: "Column Name", field: "displayName", sort: "asc" },
+      {
+        headerName: "Column Name",
+        field: "displayName",
+        sort: "asc",
+        valueGetter: (params) =>
+          secondary && !params.data?.hasPrimaryConnection ? "" : (params.data?.displayName ?? ""),
+      },
       ...(secondary
         ? [
             {
@@ -246,6 +252,7 @@ export const TableColumns = observer((props: TableColumnsProps): React.JSX.Eleme
     <div style={{ width: "98vw", height: "85vh", alignSelf: "center" }}>
       <AgGridReact<ColumnMeta>
         theme={agGridTheme}
+        modules={[RowStyleModule]}
         rowData={filteredColumns}
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}

--- a/src/components/TableDetail.tsx
+++ b/src/components/TableDetail.tsx
@@ -49,7 +49,8 @@ import { AgGridReact, CustomCellRendererProps } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 
 interface TableDetailProps {
-  connection: ToolBoxAPI.DataverseConnection | null;
+  primaryConnection: ToolBoxAPI.DataverseConnection | null;
+  secondaryConnection: ToolBoxAPI.DataverseConnection | null;
   dvService: dvService;
   isLoading: boolean;
   viewModel: ViewModel;
@@ -60,7 +61,17 @@ interface TableDetailProps {
 }
 
 export const TableDetails = observer((props: TableDetailProps): React.JSX.Element => {
-  const { connection, dvService, onLog, viewModel, table, selectedTable, isLoading, showNotification } = props;
+  const {
+    primaryConnection,
+    secondaryConnection,
+    dvService,
+    onLog,
+    viewModel,
+    table,
+    selectedTable,
+    isLoading,
+    showNotification,
+  } = props;
   const renderButtonWithTooltip = (
     label: string,
     button: React.ReactElement,
@@ -535,16 +546,16 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
     setCustomColName("");
   }
   function exportTableDetailClick(): void {
-    const title = ["Table: ", selTable.displayName, selTable.tableName];
+    const title = ["Table: ", selTable.primaryDisplayName, selTable.tableName];
     const headers = ["Attribute Name", "Value"];
     const rows = selTable.attributes.map((attr) => [attr.attributeName, attr.attributeValue]);
     const csvString = [title, headers, ...rows].map((row) => row.join(",")).join("\n");
     console.log("Attributes CSV Data:\n", csvString);
-    window.toolboxAPI.fileSystem.saveFile(`${selTable.displayName}_metadata.csv`, csvString);
+    window.toolboxAPI.fileSystem.saveFile(`${selTable.primaryDisplayName}_metadata.csv`, csvString);
   }
 
   function exportColumnsClick(): void {
-    const title = ["Table: ", selTable.displayName, selTable.tableName];
+    const title = ["Table: ", selTable.primaryDisplayName, selTable.tableName];
     const headers = ["Column Name", "Logical Name", "Type", ...viewModel.columnAttributes];
 
     const data = selTable.columns.filter((t) =>
@@ -561,11 +572,11 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
     ]);
     const csvString = [title, headers, ...rows].map((row) => row.join(",")).join("\n");
     console.log("Attributes CSV Data:\n", csvString);
-    window.toolboxAPI.fileSystem.saveFile(`${selTable.displayName}_columns_metadata.csv`, csvString);
+    window.toolboxAPI.fileSystem.saveFile(`${selTable.primaryDisplayName}_columns_metadata.csv`, csvString);
   }
 
   async function openTableSectionInBrowser(pathSuffix: string, sectionName: string): Promise<void> {
-    if (!connection) {
+    if (!primaryConnection) {
       await showNotification("No Connection", "Please connect to a Dataverse environment", "warning");
       return;
     }
@@ -593,7 +604,7 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
   }
 
   function exportSolutionsClick(): void {
-    const title = ["Table:", selTable.displayName, selTable.tableName];
+    const title = ["Table:", selTable.primaryDisplayName, selTable.tableName];
     const headers = ["Solution Name", "Unique Name", "Version", "Is Managed", "Description", "Root Component Behavior"];
     const data = selTable.solutions.map((solution) => [
       solution.solutionName,
@@ -606,21 +617,21 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
     const rows = data;
     const csvString = [title, headers, ...rows].map((row) => row.join(",")).join("\n");
     console.log("Solutions CSV Data:\n", csvString);
-    window.toolboxAPI.fileSystem.saveFile(`${selTable.displayName}_solutions_metadata.csv`, csvString);
+    window.toolboxAPI.fileSystem.saveFile(`${selTable.primaryDisplayName}_solutions_metadata.csv`, csvString);
   }
 
   function exportPrivilegesClick(): void {
-    const title = ["Table: ", selTable.displayName, selTable.tableName];
+    const title = ["Table: ", selTable.primaryDisplayName, selTable.tableName];
     const headers = ["Privilege Name", ...(selTable.privileges[0]?.attributes.map((attr) => attr.attributeName) || [])];
     const data = selTable.privileges;
     const rows = data.map((priv) => [priv.privilegeName, ...priv.attributes.map((attr) => attr.attributeValue)]);
     const csvString = [title, headers, ...rows].map((row) => row.join(",")).join("\n");
     console.log("Privileges CSV Data:\n", csvString);
-    window.toolboxAPI.fileSystem.saveFile(`${selTable.displayName}_privileges_metadata.csv`, csvString);
+    window.toolboxAPI.fileSystem.saveFile(`${selTable.primaryDisplayName}_privileges_metadata.csv`, csvString);
   }
 
   function exportRelationshipClick(): void {
-    const title = ["Table: ", selTable.displayName, selTable.tableName, "Relationship Types: ", selectedValue];
+    const title = ["Table: ", selTable.primaryDisplayName, selTable.tableName, "Relationship Types: ", selectedValue];
     const headers = [
       "Relationship Name",
       "Type",
@@ -643,7 +654,7 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
     ]);
     const csvString = [title, headers, ...rows].map((row) => row.join(",")).join("\n");
     console.log("Relationships CSV Data:\n", csvString);
-    window.toolboxAPI.fileSystem.saveFile(`${selTable.displayName}_${selectedValue}_metadata.csv`, csvString);
+    window.toolboxAPI.fileSystem.saveFile(`${selTable.primaryDisplayName}_${selectedValue}_metadata.csv`, csvString);
   }
 
   const columnDrawer = (
@@ -1013,9 +1024,9 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
                     />,
                   )}
                   {renderButtonWithTooltip(
-                    `Open ${selTable.displayName} columns in browser`,
+                    `Open ${selTable.primaryDisplayName} columns in browser`,
                     <Button
-                      aria-label={`Open ${selTable.displayName} columns in browser`}
+                      aria-label={`Open ${selTable.primaryDisplayName} columns in browser`}
                       icon={<OpenRegular />}
                       onClick={() => void openColumnsInBrowser()}
                     />,
@@ -1035,9 +1046,9 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
               {selectedValue === "keys" && (
                 <div style={{ marginLeft: "auto", padding: "10px 10px" }}>
                   {renderButtonWithTooltip(
-                    `Open ${selTable.displayName} keys in browser`,
+                    `Open ${selTable.primaryDisplayName} keys in browser`,
                     <Button
-                      aria-label={`Open ${selTable.displayName} keys in browser`}
+                      aria-label={`Open ${selTable.primaryDisplayName} keys in browser`}
                       icon={<OpenRegular />}
                       onClick={() => void openTableSectionInBrowser("/keys", "keys")}
                     />,
@@ -1064,9 +1075,9 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
                     />,
                   )}
                   {renderButtonWithTooltip(
-                    `Open ${selTable.displayName} relationships in browser`,
+                    `Open ${selTable.primaryDisplayName} relationships in browser`,
                     <Button
-                      aria-label={`Open ${selTable.displayName} relationships in browser`}
+                      aria-label={`Open ${selTable.primaryDisplayName} relationships in browser`}
                       icon={<OpenRegular />}
                       onClick={() => void openTableSectionInBrowser("/relationships", "relationships")}
                     />,
@@ -1131,9 +1142,9 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
                     />,
                   )}
                   {renderButtonWithTooltip(
-                    `Open ${selTable.displayName} views in browser`,
+                    `Open ${selTable.primaryDisplayName} views in browser`,
                     <Button
-                      aria-label={`Open ${selTable.displayName} views in browser`}
+                      aria-label={`Open ${selTable.primaryDisplayName} views in browser`}
                       icon={<OpenRegular />}
                       onClick={() => void openTableSectionInBrowser("/views", "views")}
                     />,
@@ -1207,7 +1218,8 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
             {selectedValue === "details" && tableDetails}
             {selectedValue === "columns" && (
               <TableColumns
-                connection={connection}
+                primary={primaryConnection}
+                secondary={secondaryConnection}
                 dvService={dvService}
                 isLoading={isLoading}
                 viewModel={viewModel}
@@ -1218,7 +1230,8 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
             )}
             {selectedValue === "keys" && (
               <Keys
-                connection={connection}
+                connection={primaryConnection}
+                secondaryConnection={secondaryConnection}
                 dvService={dvService}
                 isLoading={isLoading}
                 selectedTable={selTable}
@@ -1228,7 +1241,8 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
             )}
             {selectedValue === "OneToManyRelationship" && (
               <Relationships
-                connection={connection}
+                connection={primaryConnection}
+                secondaryConnection={secondaryConnection}
                 dvService={dvService}
                 isLoading={isLoading}
                 selectedTable={selTable}
@@ -1240,7 +1254,8 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
             )}
             {selectedValue === "ManyToOneRelationship" && (
               <Relationships
-                connection={connection}
+                connection={primaryConnection}
+                secondaryConnection={secondaryConnection}
                 dvService={dvService}
                 isLoading={isLoading}
                 selectedTable={selTable}
@@ -1252,7 +1267,8 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
             )}
             {selectedValue === "ManyToManyRelationship" && (
               <Relationships
-                connection={connection}
+                connection={primaryConnection}
+                secondaryConnection={secondaryConnection}
                 dvService={dvService}
                 isLoading={isLoading}
                 selectedTable={selTable}
@@ -1264,7 +1280,8 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
             )}
             {selectedValue === "Privileges" && (
               <Privileges
-                connection={connection}
+                connection={primaryConnection}
+                secondaryConnection={secondaryConnection}
                 dvService={dvService}
                 isLoading={isLoading}
                 selectedTable={selTable}
@@ -1274,7 +1291,8 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
             )}
             {selectedValue === "Solutions" && (
               <Solutions
-                connection={connection}
+                connection={primaryConnection}
+                secondaryConnection={secondaryConnection}
                 dvService={dvService}
                 isLoading={isLoading}
                 selectedTable={selTable}
@@ -1284,7 +1302,8 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
             )}
             {selectedValue === "Views" && (
               <Views
-                connection={connection}
+                connection={primaryConnection}
+                secondaryConnection={secondaryConnection}
                 dvService={dvService}
                 isLoading={isLoading}
                 selectedTable={selTable}
@@ -1295,7 +1314,8 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
             )}
             {selectedValue === "BusinessProcessFlows" && (
               <BusinessProcessFlows
-                connection={connection}
+                connection={primaryConnection}
+                secondaryConnection={secondaryConnection}
                 dvService={dvService}
                 isLoading={isLoading}
                 selectedTable={selTable}
@@ -1306,7 +1326,8 @@ export const TableDetails = observer((props: TableDetailProps): React.JSX.Elemen
             )}
             {selectedValue === "BusinessRules" && (
               <BusinessRules
-                connection={connection}
+                connection={primaryConnection}
+                secondaryConnection={secondaryConnection}
                 dvService={dvService}
                 isLoading={isLoading}
                 selectedTable={selTable}

--- a/src/components/Views.tsx
+++ b/src/components/Views.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react";
 import { dvService } from "../utils/dataverse";
 import { TableMeta } from "../model/tableMeta";
 import { Spinner } from "@fluentui/react-components";
-import { ColDef } from "ag-grid-community";
+import { ColDef, RowStyleModule } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { ViewMeta } from "../model/view";
@@ -80,7 +80,14 @@ export const Views = observer((props: ViewsProps): React.JSX.Element => {
 
   const colDefs = React.useMemo<ColDef<ViewMeta>[]>(
     () => [
-      { headerName: "Name", field: "viewName", flex: 2, sort: "asc" },
+      {
+        headerName: "Name",
+        field: "viewName",
+        flex: 2,
+        sort: "asc",
+        valueGetter: (params) =>
+          secondaryConnection && !params.data?.hasPrimaryConnection ? "" : (params.data?.viewName ?? ""),
+      },
       ...(secondaryConnection
         ? [
             {
@@ -121,6 +128,7 @@ export const Views = observer((props: ViewsProps): React.JSX.Element => {
     <div style={{ width: "98vw", height: "85vh", alignSelf: "center" }}>
       <AgGridReact<ViewMeta>
         theme={agGridTheme}
+        modules={[RowStyleModule]}
         rowData={filteredViews}
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}

--- a/src/components/Views.tsx
+++ b/src/components/Views.tsx
@@ -7,9 +7,11 @@ import { ColDef } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { agGridTheme } from "../config/agGridConfig";
 import { ViewMeta } from "../model/view";
+import { createConnectionRowClassRules, mergeConnectionComparisonRecords } from "../utils/connectionComparison";
 
 interface ViewsProps {
   connection: ToolBoxAPI.DataverseConnection | null;
+  secondaryConnection: ToolBoxAPI.DataverseConnection | null;
   dvService: dvService;
   isLoading: boolean;
   selectedTable: TableMeta;
@@ -19,7 +21,7 @@ interface ViewsProps {
 }
 
 export const Views = observer((props: ViewsProps): React.JSX.Element => {
-  const { connection, dvService, onLog, selectedTable, showNotification, viewAttributes } = props;
+  const { connection, secondaryConnection, dvService, onLog, selectedTable, showNotification, viewAttributes } = props;
   const [loadingMeta, setLoadingMeta] = React.useState(false);
 
   const filteredViews = React.useMemo(() => {
@@ -41,21 +43,27 @@ export const Views = observer((props: ViewsProps): React.JSX.Element => {
   }, [selectedTable]);
 
   async function getViews() {
-    if (!connection) {
+    const canLoadPrimary = Boolean(connection && selectedTable.hasPrimaryConnection);
+    const canLoadSecondary = Boolean(secondaryConnection && selectedTable.hasSecondaryConnection);
+
+    if (!canLoadPrimary && !canLoadSecondary) {
       await showNotification("No Connection", "Please connect to a Dataverse environment", "warning");
       return;
     }
 
     setLoadingMeta(true);
-    await dvService
-      .getViewsForTable(selectedTable)
-      .then((views) => {
-        selectedTable.views = views;
-        onLog(`Loaded ${views.length} views for table: ${selectedTable.tableName}`, "success");
-      })
-      .catch((error: { message: any }) => {
-        onLog(`Error loading views for table ${selectedTable.tableName}: ${error.message}`, "error");
-      });
+    const [primaryViews, secondaryViews] = await Promise.all([
+      canLoadPrimary ? dvService.getViewsForTable(selectedTable, "primary") : Promise.resolve([]),
+      canLoadSecondary ? dvService.getViewsForTable(selectedTable, "secondary") : Promise.resolve([]),
+    ]);
+
+    selectedTable.views = mergeConnectionComparisonRecords(
+      primaryViews,
+      secondaryViews,
+      (view) => `${view.type}:${view.viewName}`,
+      (view) => view.viewName,
+    );
+    onLog(`Loaded ${selectedTable.views.length} views for table: ${selectedTable.tableName}`, "success");
     setLoadingMeta(false);
   }
 
@@ -73,6 +81,16 @@ export const Views = observer((props: ViewsProps): React.JSX.Element => {
   const colDefs = React.useMemo<ColDef<ViewMeta>[]>(
     () => [
       { headerName: "Name", field: "viewName", flex: 2, sort: "asc" },
+      ...(secondaryConnection
+        ? [
+            {
+              headerName: secondaryConnection.name ? `2nd Name (${secondaryConnection.name})` : "2nd Name",
+              field: "secondaryDisplayName",
+              valueGetter: (params) =>
+                params.data?.hasSecondaryConnection ? params.data.secondaryDisplayName || "" : "",
+            } as ColDef<ViewMeta>,
+          ]
+        : []),
       { headerName: "Type", field: "type" },
       ...viewAttributes.map(
         (attrName) =>
@@ -85,7 +103,7 @@ export const Views = observer((props: ViewsProps): React.JSX.Element => {
           }) as ColDef<ViewMeta>,
       ),
     ],
-    [viewAttributes],
+    [secondaryConnection, viewAttributes],
   );
 
   const getViewRowId = React.useCallback((view: ViewMeta) => {
@@ -93,6 +111,11 @@ export const Views = observer((props: ViewsProps): React.JSX.Element => {
     const userQueryId = view.attributes.find((a) => a.attributeName === "userqueryid")?.attributeValue;
     return savedQueryId || userQueryId || `${view.type}:${view.viewName}`;
   }, []);
+
+  const rowClassRules = React.useMemo(
+    () => createConnectionRowClassRules<ViewMeta>(Boolean(secondaryConnection)),
+    [secondaryConnection],
+  );
 
   const viewsGrid = (
     <div style={{ width: "98vw", height: "85vh", alignSelf: "center" }}>
@@ -102,6 +125,7 @@ export const Views = observer((props: ViewsProps): React.JSX.Element => {
         columnDefs={colDefs}
         defaultColDef={defaultColDefs}
         domLayout="normal"
+        rowClassRules={rowClassRules}
         getRowId={(params) => (params.data ? getViewRowId(params.data) : "")}
         enableCellTextSelection={true}
       />

--- a/src/components/Views.tsx
+++ b/src/components/Views.tsx
@@ -62,6 +62,7 @@ export const Views = observer((props: ViewsProps): React.JSX.Element => {
       secondaryViews,
       (view) => `${view.type}:${view.viewName}`,
       (view) => view.viewName,
+      ["viewName"],
     );
     onLog(`Loaded ${selectedTable.views.length} views for table: ${selectedTable.tableName}`, "success");
     setLoadingMeta(false);

--- a/src/hooks/useToolboxAPI.ts
+++ b/src/hooks/useToolboxAPI.ts
@@ -7,15 +7,18 @@ export type LogEntry = {
 };
 
 export function useConnection() {
-  const [connection, setConnection] = useState<ToolBoxAPI.DataverseConnection | null>(null);
+  const [primaryConnection, setPrimaryConnection] = useState<ToolBoxAPI.DataverseConnection | null>(null);
+  const [secondaryConnection, setSecondaryConnection] = useState<ToolBoxAPI.DataverseConnection | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   const refreshConnection = useCallback(async () => {
     console.log("Refreshing active connection...");
     try {
-      const conn = await window.toolboxAPI.connections.getActiveConnection();
-      setConnection(conn);
-      console.log("Active connection refreshed:", conn);
+      const primaryConn = await window.toolboxAPI.connections.getActiveConnection();
+      const secondaryConn = await window.toolboxAPI.connections.getSecondaryConnection();
+      setPrimaryConnection(primaryConn);
+      setSecondaryConnection(secondaryConn);
+      console.log("Active connection refreshed:", primaryConn, secondaryConn);
     } catch (error) {
       console.error("Error refreshing connection:", error);
     } finally {
@@ -27,7 +30,7 @@ export function useConnection() {
     refreshConnection();
   }, [refreshConnection]);
 
-  return { connection, isLoading, refreshConnection };
+  return { primaryConnection, secondaryConnection, isLoading, refreshConnection };
 }
 
 export function useToolboxEvents(onEvent: (event: string, data: any) => void) {

--- a/src/index.css
+++ b/src/index.css
@@ -340,6 +340,24 @@ body {
   }
 }
 
+body[data-ag-theme-mode="light"] .ag-row.table-row-primary-only .ag-cell {
+  background-color: rgba(255, 242, 204, 0.92) !important;
+}
+
+body[data-ag-theme-mode="light"] .ag-row.table-row-secondary-only .ag-cell {
+  background-color: rgba(221, 242, 255, 0.92) !important;
+}
+
+body[data-ag-theme-mode="dark"] .ag-row.table-row-primary-only .ag-cell {
+  background-color: rgba(153, 120, 25, 0.45) !important;
+  color: #f8f8f8;
+}
+
+body[data-ag-theme-mode="dark"] .ag-row.table-row-secondary-only .ag-cell {
+  background-color: rgba(31, 102, 146, 0.5) !important;
+  color: #f8f8f8;
+}
+
 .output::-webkit-scrollbar,
 .log::-webkit-scrollbar {
   width: 8px;

--- a/src/model/businessProcessFlow.tsx
+++ b/src/model/businessProcessFlow.tsx
@@ -4,11 +4,16 @@ import { Attribute } from "./tableMeta";
 export class BusinessProcessFlowMeta {
   flowName: string;
   type: string;
+  secondaryDisplayName?: string;
+  hasPrimaryConnection: boolean;
+  hasSecondaryConnection: boolean;
   attributes: Attribute[] = [];
 
   constructor() {
     this.flowName = "";
     this.type = "Business Process Flow";
+    this.hasPrimaryConnection = false;
+    this.hasSecondaryConnection = false;
     makeAutoObservable(this);
   }
 }

--- a/src/model/businessRule.tsx
+++ b/src/model/businessRule.tsx
@@ -4,11 +4,16 @@ import { Attribute } from "./tableMeta";
 export class BusinessRuleMeta {
   ruleName: string;
   type: string;
+  secondaryDisplayName?: string;
+  hasPrimaryConnection: boolean;
+  hasSecondaryConnection: boolean;
   attributes: Attribute[] = [];
 
   constructor() {
     this.ruleName = "";
     this.type = "Business Rule";
+    this.hasPrimaryConnection = false;
+    this.hasSecondaryConnection = false;
     makeAutoObservable(this);
   }
 }

--- a/src/model/columnMeta.tsx
+++ b/src/model/columnMeta.tsx
@@ -3,6 +3,9 @@ import { makeAutoObservable } from "mobx";
 export class ColumnMeta {
   columnName: string;
   displayName: string;
+  secondaryDisplayName?: string;
+  hasPrimaryConnection: boolean;
+  hasSecondaryConnection: boolean;
   dataType: string;
 
   attributes: ColumnAttribute[] = [];
@@ -10,6 +13,8 @@ export class ColumnMeta {
   constructor() {
     this.columnName = "";
     this.displayName = "";
+    this.hasPrimaryConnection = false;
+    this.hasSecondaryConnection = false;
     this.dataType = "";
     makeAutoObservable(this);
   }

--- a/src/model/solution.tsx
+++ b/src/model/solution.tsx
@@ -4,17 +4,22 @@ export class Solution {
   solutionId: string;
   solutionName: string;
   uniqueName: string;
+  secondaryDisplayName?: string;
+  hasPrimaryConnection: boolean;
+  hasSecondaryConnection: boolean;
   description?: string;
   version?: string;
   isManaged?: boolean;
   subcomponents?: boolean;
-  
+
   attributes: { attributeName: string; attributeValue: string }[];
 
   constructor() {
     this.solutionId = "";
     this.solutionName = "";
     this.uniqueName = "";
+    this.hasPrimaryConnection = false;
+    this.hasSecondaryConnection = false;
     this.attributes = [];
     makeAutoObservable(this);
   }

--- a/src/model/tableMeta.tsx
+++ b/src/model/tableMeta.tsx
@@ -7,7 +7,10 @@ import { BusinessRuleMeta } from "./businessRule";
 
 export class TableMeta {
   tableName: string;
-  displayName: string;
+  primaryDisplayName: string;
+  secondaryDisplayName?: string;
+  hasPrimaryConnection: boolean;
+  hasSecondaryConnection: boolean;
   metaId: string;
 
   columns: ColumnMeta[] = [];
@@ -31,7 +34,9 @@ export class TableMeta {
 
   constructor() {
     this.tableName = "";
-    this.displayName = "";
+    this.primaryDisplayName = "";
+    this.hasPrimaryConnection = false;
+    this.hasSecondaryConnection = false;
     this.metaId = "";
 
     makeAutoObservable(this);
@@ -50,11 +55,16 @@ export class Attribute {
 
 export class KeyMeta {
   keyName: string;
+  secondaryDisplayName?: string;
+  hasPrimaryConnection: boolean;
+  hasSecondaryConnection: boolean;
 
   attributes: Attribute[] = [];
 
   constructor() {
     this.keyName = "";
+    this.hasPrimaryConnection = false;
+    this.hasSecondaryConnection = false;
     makeAutoObservable(this);
   }
 }
@@ -62,11 +72,16 @@ export class KeyMeta {
 export class RelationshipMeta {
   relationshipName: string;
   type: string;
+  secondaryDisplayName?: string;
+  hasPrimaryConnection: boolean;
+  hasSecondaryConnection: boolean;
   attributes: Attribute[] = [];
 
   constructor() {
     this.relationshipName = "";
     this.type = "";
+    this.hasPrimaryConnection = false;
+    this.hasSecondaryConnection = false;
     makeAutoObservable(this);
   }
 }
@@ -84,10 +99,15 @@ export class RelationshipAttribute {
 
 export class PrivilegeMeta {
   privilegeName: string;
+  secondaryDisplayName?: string;
+  hasPrimaryConnection: boolean;
+  hasSecondaryConnection: boolean;
   attributes: Attribute[] = [];
 
   constructor() {
     this.privilegeName = "";
+    this.hasPrimaryConnection = false;
+    this.hasSecondaryConnection = false;
     makeAutoObservable(this);
   }
 }

--- a/src/model/view.tsx
+++ b/src/model/view.tsx
@@ -4,11 +4,16 @@ import { Attribute } from "./tableMeta";
 export class ViewMeta {
   viewName: string;
   type: string;
+  secondaryDisplayName?: string;
+  hasPrimaryConnection: boolean;
+  hasSecondaryConnection: boolean;
   attributes: Attribute[] = [];
 
   constructor() {
     this.viewName = "";
     this.type = "";
+    this.hasPrimaryConnection = false;
+    this.hasSecondaryConnection = false;
 
     makeAutoObservable(this);
   }

--- a/src/utils/connectionComparison.ts
+++ b/src/utils/connectionComparison.ts
@@ -1,0 +1,46 @@
+export type ConnectionComparisonRecord = {
+  hasPrimaryConnection: boolean;
+  hasSecondaryConnection: boolean;
+  secondaryDisplayName?: string;
+};
+
+export function mergeConnectionComparisonRecords<T extends ConnectionComparisonRecord>(
+  primaryRecords: T[],
+  secondaryRecords: T[],
+  getKey: (record: T) => string,
+  getDisplayName: (record: T) => string,
+): T[] {
+  const mergedRecords = new Map<string, T>();
+
+  primaryRecords.forEach((record) => {
+    record.hasPrimaryConnection = true;
+    record.hasSecondaryConnection = false;
+    mergedRecords.set(getKey(record), record);
+  });
+
+  secondaryRecords.forEach((record) => {
+    const mergedRecord = mergedRecords.get(getKey(record));
+
+    if (mergedRecord) {
+      mergedRecord.hasSecondaryConnection = true;
+      mergedRecord.secondaryDisplayName = getDisplayName(record);
+      return;
+    }
+
+    record.hasPrimaryConnection = false;
+    record.hasSecondaryConnection = true;
+    record.secondaryDisplayName = getDisplayName(record);
+    mergedRecords.set(getKey(record), record);
+  });
+
+  return Array.from(mergedRecords.values());
+}
+
+export function createConnectionRowClassRules<T extends ConnectionComparisonRecord>(hasSecondaryConnection: boolean) {
+  return {
+    "table-row-primary-only": (params: { data?: T }) =>
+      Boolean(hasSecondaryConnection && params.data?.hasPrimaryConnection && !params.data?.hasSecondaryConnection),
+    "table-row-secondary-only": (params: { data?: T }) =>
+      Boolean(hasSecondaryConnection && !params.data?.hasPrimaryConnection && params.data?.hasSecondaryConnection),
+  };
+}

--- a/src/utils/connectionComparison.ts
+++ b/src/utils/connectionComparison.ts
@@ -9,6 +9,7 @@ export function mergeConnectionComparisonRecords<T extends ConnectionComparisonR
   secondaryRecords: T[],
   getKey: (record: T) => string,
   getDisplayName: (record: T) => string,
+  primaryDisplayFieldsToClear: string[] = [],
 ): T[] {
   const mergedRecords = new Map<string, T>();
 
@@ -27,10 +28,18 @@ export function mergeConnectionComparisonRecords<T extends ConnectionComparisonR
       return;
     }
 
-    record.hasPrimaryConnection = false;
-    record.hasSecondaryConnection = true;
-    record.secondaryDisplayName = getDisplayName(record);
-    mergedRecords.set(getKey(record), record);
+    const secondaryOnlyRecord = { ...record } as T;
+    const secondaryOnlyRecordFields = secondaryOnlyRecord as Record<string, unknown>;
+    primaryDisplayFieldsToClear.forEach((fieldName) => {
+      if (typeof secondaryOnlyRecordFields[fieldName] === "string") {
+        secondaryOnlyRecordFields[fieldName] = "";
+      }
+    });
+
+    secondaryOnlyRecord.hasPrimaryConnection = false;
+    secondaryOnlyRecord.hasSecondaryConnection = true;
+    secondaryOnlyRecord.secondaryDisplayName = getDisplayName(record);
+    mergedRecords.set(getKey(record), secondaryOnlyRecord as T);
   });
 
   return Array.from(mergedRecords.values());

--- a/src/utils/dataverse.tsx
+++ b/src/utils/dataverse.tsx
@@ -12,25 +12,41 @@ interface RetrieveCurrentOrganizationResponse {
 }
 
 interface dvServiceProps {
-  connection: ToolBoxAPI.DataverseConnection | null;
+  primaryConnection: ToolBoxAPI.DataverseConnection | null;
+  secondaryConnection: ToolBoxAPI.DataverseConnection | null;
   dvApi: DataverseAPI.API;
   onLog: (message: string, type?: "info" | "success" | "warning" | "error") => void;
 }
 export class dvService {
-  connection: ToolBoxAPI.DataverseConnection | null;
+  primaryConnection: ToolBoxAPI.DataverseConnection | null;
+  secondaryConnection: ToolBoxAPI.DataverseConnection | null;
   dvApi: DataverseAPI.API;
   onLog: (message: string, type?: "info" | "success" | "warning" | "error") => void;
   private cachedEnvironmentId: string | null = null;
   private environmentIdRequest: Promise<string> | null = null;
 
   constructor(props: dvServiceProps) {
-    this.connection = props.connection;
+    this.primaryConnection = props.primaryConnection;
+    this.secondaryConnection = props.secondaryConnection;
     this.dvApi = props.dvApi;
     this.onLog = props.onLog;
   }
 
-  async getEnvironmentId(): Promise<string> {
-    if (!this.connection) {
+  private resolveConnection(connectionTarget: "primary" | "secondary") {
+    return connectionTarget === "secondary" ? this.secondaryConnection : this.primaryConnection;
+  }
+
+  private queryData(odataQuery: string, connectionTarget: "primary" | "secondary" = "primary") {
+    return this.dvApi.queryData(odataQuery, connectionTarget);
+  }
+
+  private fetchXmlQuery(fetchXml: string, connectionTarget: "primary" | "secondary" = "primary") {
+    return this.dvApi.fetchXmlQuery(fetchXml, connectionTarget);
+  }
+
+  async getEnvironmentId(connectionTarget: "primary" | "secondary" = "primary"): Promise<string> {
+    const connection = this.resolveConnection(connectionTarget);
+    if (!connection) {
       throw new Error("No connection available");
     }
 
@@ -45,8 +61,7 @@ export class dvService {
     const requestPath =
       "RetrieveCurrentOrganization(AccessType=@p1)?@p1=Microsoft.Dynamics.CRM.EndpointAccessType'Default'";
 
-    this.environmentIdRequest = this.dvApi
-      .queryData(requestPath)
+    this.environmentIdRequest = this.queryData(requestPath, connectionTarget)
       .then((response) => {
         const environmentId = (response as RetrieveCurrentOrganizationResponse)?.Detail?.EnvironmentId?.trim();
 
@@ -64,12 +79,16 @@ export class dvService {
     return this.environmentIdRequest;
   }
 
-  async getTableBrowserUrl(tableMetaId: string, pathSuffix = ""): Promise<string> {
+  async getTableBrowserUrl(
+    tableMetaId: string,
+    pathSuffix = "",
+    connectionTarget: "primary" | "secondary" = "primary",
+  ): Promise<string> {
     if (!tableMetaId) {
       throw new Error("No table metadata ID available");
     }
 
-    const environmentId = await this.getEnvironmentId();
+    const environmentId = await this.getEnvironmentId(connectionTarget);
     const normalizedSuffix = pathSuffix ? (pathSuffix.startsWith("/") ? pathSuffix : `/${pathSuffix}`) : "";
 
     return `https://make.powerapps.com/environments/${encodeURIComponent(environmentId)}/entities/${encodeURIComponent(tableMetaId)}${normalizedSuffix}`;
@@ -78,19 +97,20 @@ export class dvService {
   /// Get metadata for all tables
   /// @returns Promise<TableMeta[]> - A promise that resolves to an array of TableMeta
   /// @todo : Need to swap back to toolbox code when fixed
-  async getAllTables(): Promise<TableMeta[]> {
+  async getAllTables(primary: boolean): Promise<TableMeta[]> {
     this.onLog("Fetching table metadata...", "info");
-    if (!this.connection) {
+    const connection = primary ? this.primaryConnection : this.secondaryConnection;
+    if (!connection) {
       throw new Error("No connection available");
     }
     //const tables = await this.dvApi.getAllEntitiesMetadata();
-    const tables = await this.dvApi.queryData("EntityDefinitions");
+    const tables = await this.queryData("EntityDefinitions", primary ? "primary" : "secondary");
     //console.log("Tables fetched: ", tables.value);
     const tableMetaList: TableMeta[] = (tables.value as any[]).map((table: any) => {
       //console.log("Table fetched: ", table);
       const tableMeta = new TableMeta();
       tableMeta.tableName = String(table.LogicalName);
-      tableMeta.displayName = table.DisplayName?.LocalizedLabels?.[0]?.Label || table.LogicalName;
+      tableMeta.primaryDisplayName = table.DisplayName?.LocalizedLabels?.[0]?.Label || table.LogicalName;
       tableMeta.metaId = table.MetadataId || "";
       tableMeta.attributes = [];
       tableMeta.typeCode = table.ObjectTypeCode;
@@ -118,14 +138,15 @@ export class dvService {
   // @todo: Need to swap back to toolbox code when fixed
   // @param table - The logical name of the table
   // @returns Promise<ColumnMeta[]> - A promise that resolves to an array of ColumnMeta
-  async getColumnsMeta(table: string): Promise<ColumnMeta[]> {
+  async getColumnsMeta(table: string, connectionTarget: "primary" | "secondary" = "primary"): Promise<ColumnMeta[]> {
     this.onLog(`Fetching column metadata for table: ${table}`, "info");
-    if (!this.connection) {
+    const connection = this.resolveConnection(connectionTarget);
+    if (!connection) {
       throw new Error("No connection available");
     }
     try {
       //const meta = await this.dvApi.getEntityMetadata(table, true);
-      const meta = await this.dvApi.queryData(`EntityDefinitions(LogicalName='${table}')/Attributes`);
+      const meta = await this.queryData(`EntityDefinitions(LogicalName='${table}')/Attributes`, connectionTarget);
 
       //  console.log("Attributes fetched: ", meta.value);
 
@@ -161,17 +182,19 @@ export class dvService {
     }
   }
 
-  async getSolutions(managed: boolean): Promise<Solution[]> {
+  async getSolutions(managed: boolean, connectionTarget: "primary" | "secondary" = "primary"): Promise<Solution[]> {
     this.onLog("Fetching solutions...", "info");
-    console.log("Fetching solutions, connection: ", this.connection);
-    if (!this.connection) {
+    const connection = this.resolveConnection(connectionTarget);
+    console.log("Fetching solutions, connection: ", connection);
+    if (!connection) {
       throw new Error("No connection available");
     }
 
-    const solutionsData = await this.dvApi.queryData(
+    const solutionsData = await this.queryData(
       "solutions?$filter=(isvisible eq true) and ismanaged eq " +
         (managed ? "true" : "false") +
         " &$select=friendlyname,uniquename&$orderby=createdon desc",
+      connectionTarget,
     );
     const solutions: Solution[] = (solutionsData.value as any[]).map((sol: any) => {
       const solution = new Solution();
@@ -184,15 +207,19 @@ export class dvService {
     return solutions;
   }
 
-  async getSolutionTables(solutionUniqueName: string): Promise<TableMeta[]> {
+  async getSolutionTables(
+    solutionUniqueName: string,
+    connectionTarget: "primary" | "secondary" = "primary",
+  ): Promise<TableMeta[]> {
     this.onLog(`Fetching tables for solution: ${solutionUniqueName}`, "info");
-    if (!this.connection) {
+    const connection = this.resolveConnection(connectionTarget);
+    if (!connection) {
       throw new Error("No connection available");
     }
     const query = `solutioncomponents?$select=objectid&$expand=solutionid($select=solutionid)&$filter=(componenttype eq 1) and (solutionid/uniquename eq '${solutionUniqueName}')`;
 
     try {
-      const componentsData = await this.dvApi.queryData(query);
+      const componentsData = await this.queryData(query, connectionTarget);
       console.log("Solution components fetched: ", componentsData.value);
       const compArray = componentsData.value as any[];
 
@@ -201,7 +228,7 @@ export class dvService {
         if (!objectId) return null;
         try {
           // Try fetching the entity definition by id
-          const entityMeta = await this.dvApi.queryData(`EntityDefinitions(${objectId})`);
+          const entityMeta = await this.queryData(`EntityDefinitions(${objectId})`, connectionTarget);
           // normalize the response: if entityMeta has a value array, use the first element, otherwise use the object itself
           const src: any = Array.isArray((entityMeta as any)?.value)
             ? (entityMeta as any).value[0]
@@ -209,7 +236,7 @@ export class dvService {
 
           const tm = new TableMeta();
           tm.tableName = src?.LogicalName || String(objectId);
-          tm.displayName = src?.DisplayName?.LocalizedLabels?.[0]?.Label || tm.tableName;
+          tm.primaryDisplayName = src?.DisplayName?.LocalizedLabels?.[0]?.Label || tm.tableName;
           tm.metaId = src?.MetadataId || "";
           tm.attributes = [];
           tm.typeCode = src?.ObjectTypeCode;
@@ -248,13 +275,66 @@ export class dvService {
     }
   }
 
-  async getKeysMeta(selectedTable: TableMeta): Promise<KeyMeta[]> {
-    if (!this.connection) {
+  async getTableByLogicalName(
+    logicalName: string,
+    connectionTarget: "primary" | "secondary" = "primary",
+  ): Promise<TableMeta | null> {
+    const connection = this.resolveConnection(connectionTarget);
+    if (!connection) {
+      throw new Error("No connection available");
+    }
+
+    if (!logicalName?.trim()) {
+      return null;
+    }
+
+    try {
+      const tableData = await this.queryData(`EntityDefinitions(LogicalName='${logicalName}')`, connectionTarget);
+      const src: any = Array.isArray((tableData as any)?.value) ? (tableData as any).value[0] : (tableData as any);
+
+      if (!src?.LogicalName) {
+        return null;
+      }
+
+      const tm = new TableMeta();
+      tm.tableName = src.LogicalName;
+      tm.primaryDisplayName = src.DisplayName?.LocalizedLabels?.[0]?.Label || src.LogicalName;
+      tm.metaId = src.MetadataId || "";
+      tm.typeCode = src.ObjectTypeCode;
+
+      Object.keys(src).forEach((prop) => {
+        const value = src[prop];
+        if (typeof value === "function") return;
+        try {
+          tm.attributes.push({
+            attributeName: prop,
+            attributeValue: typeof value === "string" ? value : JSON.stringify(value),
+          });
+        } catch {
+          tm.attributes.push({
+            attributeName: prop,
+            attributeValue: String(value),
+          });
+        }
+      });
+
+      return tm;
+    } catch {
+      return null;
+    }
+  }
+
+  async getKeysMeta(
+    selectedTable: TableMeta,
+    connectionTarget: "primary" | "secondary" = "primary",
+  ): Promise<KeyMeta[]> {
+    const connection = this.resolveConnection(connectionTarget);
+    if (!connection) {
       throw new Error("No connection available");
     }
     try {
       this.onLog(`Fetching keys metadata for table: ${selectedTable.tableName}`, "info");
-      const meta = await this.dvApi.queryData(`EntityDefinitions(${selectedTable.metaId})/Keys`);
+      const meta = await this.queryData(`EntityDefinitions(${selectedTable.metaId})/Keys`, connectionTarget);
       const keyMetaList: KeyMeta[] = (meta.value as any).map((key: any) => {
         // console.log("Processing key: ", key);
         const keyMeta = new KeyMeta();
@@ -287,13 +367,17 @@ export class dvService {
     }
   }
 
-  async getPrivilegesMetadata(selectedTable: TableMeta): Promise<PrivilegeMeta[]> {
-    if (!this.connection) {
+  async getPrivilegesMetadata(
+    selectedTable: TableMeta,
+    connectionTarget: "primary" | "secondary" = "primary",
+  ): Promise<PrivilegeMeta[]> {
+    const connection = this.resolveConnection(connectionTarget);
+    if (!connection) {
       throw new Error("No connection available");
     }
     try {
       this.onLog(`Fetching privileges metadata for table: ${selectedTable.tableName}`, "info");
-      const meta = await this.dvApi.queryData(`EntityDefinitions(${selectedTable.metaId})/Privileges`);
+      const meta = await this.queryData(`EntityDefinitions(${selectedTable.metaId})/Privileges`, connectionTarget);
       const keyMetaList: PrivilegeMeta[] = (meta.value as any).map((privilege: any) => {
         // console.log("Processing key: ", privilege);
         const privMeta = new PrivilegeMeta();
@@ -326,13 +410,18 @@ export class dvService {
     }
   }
 
-  async getRelationshipsMeta(selectedTable: TableMeta, type: string): Promise<RelationshipMeta[]> {
-    if (!this.connection) {
+  async getRelationshipsMeta(
+    selectedTable: TableMeta,
+    type: string,
+    connectionTarget: "primary" | "secondary" = "primary",
+  ): Promise<RelationshipMeta[]> {
+    const connection = this.resolveConnection(connectionTarget);
+    if (!connection) {
       throw new Error("No connection available");
     }
     try {
       this.onLog(`Fetching relationships metadata for table: ${selectedTable.tableName} type: ${type}`, "info");
-      const meta = await this.dvApi.queryData(`EntityDefinitions(${selectedTable.metaId})/${type}s`);
+      const meta = await this.queryData(`EntityDefinitions(${selectedTable.metaId})/${type}s`, connectionTarget);
       const relationships: RelationshipMeta[] = (meta.value as any).map((relationship: any) => {
         const relationshipMeta = new RelationshipMeta();
         relationshipMeta.relationshipName = relationship.SchemaName;
@@ -365,8 +454,12 @@ export class dvService {
     }
   }
 
-  async getSolutionsForTable(selectedTable: TableMeta): Promise<Solution[]> {
-    if (!this.connection) {
+  async getSolutionsForTable(
+    selectedTable: TableMeta,
+    connectionTarget: "primary" | "secondary" = "primary",
+  ): Promise<Solution[]> {
+    const connection = this.resolveConnection(connectionTarget);
+    if (!connection) {
       throw new Error("No connection available");
     }
     try {
@@ -392,7 +485,7 @@ export class dvService {
   </entity>
 </fetch>`;
       console.log("FetchXML for solutions: ", fetchXml);
-      const meta = await this.dvApi.fetchXmlQuery(fetchXml);
+      const meta = await this.fetchXmlQuery(fetchXml, connectionTarget);
       console.log("Solutions fetched: ", meta);
       const solutions: Solution[] = (meta.value as any).map((solution: any) => {
         // console.log("Processing Solution: ", solution);
@@ -432,8 +525,12 @@ export class dvService {
     }
   }
 
-  async getViewsForTable(selectedTable: TableMeta): Promise<ViewMeta[]> {
-    if (!this.connection) {
+  async getViewsForTable(
+    selectedTable: TableMeta,
+    connectionTarget: "primary" | "secondary" = "primary",
+  ): Promise<ViewMeta[]> {
+    const connection = this.resolveConnection(connectionTarget);
+    if (!connection) {
       throw new Error("No connection available");
     }
 
@@ -445,8 +542,8 @@ export class dvService {
       const personalViewsQuery = "userqueries?$filter=returnedtypecode eq '" + selectedTable.tableName + "'";
 
       const [systemViewsData, personalViewsData] = await Promise.all([
-        this.dvApi.queryData(systemViewsQuery),
-        this.dvApi.queryData(personalViewsQuery),
+        this.queryData(systemViewsQuery, connectionTarget),
+        this.queryData(personalViewsQuery, connectionTarget),
       ]);
 
       const systemViews = (systemViewsData.value as any[]).map((view: any) => {
@@ -507,8 +604,12 @@ export class dvService {
     }
   }
 
-  async getBusinessProcessFlowsForTable(selectedTable: TableMeta): Promise<BusinessProcessFlowMeta[]> {
-    if (!this.connection) {
+  async getBusinessProcessFlowsForTable(
+    selectedTable: TableMeta,
+    connectionTarget: "primary" | "secondary" = "primary",
+  ): Promise<BusinessProcessFlowMeta[]> {
+    const connection = this.resolveConnection(connectionTarget);
+    if (!connection) {
       throw new Error("No connection available");
     }
 
@@ -517,7 +618,7 @@ export class dvService {
 
       const bpfQuery = "workflows?$filter=category eq 4 and primaryentity eq '" + selectedTable.tableName + "'";
 
-      const bpfData = await this.dvApi.queryData(bpfQuery);
+      const bpfData = await this.queryData(bpfQuery, connectionTarget);
 
       const flows = (bpfData.value as any[]).map((flow: any) => {
         const bpfMeta = new BusinessProcessFlowMeta();
@@ -553,8 +654,12 @@ export class dvService {
     }
   }
 
-  async getBusinessRulesForTable(selectedTable: TableMeta): Promise<BusinessRuleMeta[]> {
-    if (!this.connection) {
+  async getBusinessRulesForTable(
+    selectedTable: TableMeta,
+    connectionTarget: "primary" | "secondary" = "primary",
+  ): Promise<BusinessRuleMeta[]> {
+    const connection = this.resolveConnection(connectionTarget);
+    if (!connection) {
       throw new Error("No connection available");
     }
 
@@ -564,7 +669,7 @@ export class dvService {
       const businessRulesQuery =
         "workflows?$filter=category eq 2 and primaryentity eq '" + selectedTable.tableName + "'";
 
-      const businessRulesData = await this.dvApi.queryData(businessRulesQuery);
+      const businessRulesData = await this.queryData(businessRulesQuery, connectionTarget);
 
       const rules = (businessRulesData.value as any[]).map((rule: any) => {
         const ruleMeta = new BusinessRuleMeta();

--- a/src/utils/dataverse.tsx
+++ b/src/utils/dataverse.tsx
@@ -22,8 +22,8 @@ export class dvService {
   secondaryConnection: ToolBoxAPI.DataverseConnection | null;
   dvApi: DataverseAPI.API;
   onLog: (message: string, type?: "info" | "success" | "warning" | "error") => void;
-  private cachedEnvironmentId: string | null = null;
-  private environmentIdRequest: Promise<string> | null = null;
+  private cachedEnvironmentIds = new Map<"primary" | "secondary", string>();
+  private environmentIdRequests = new Map<"primary" | "secondary", Promise<string>>();
 
   constructor(props: dvServiceProps) {
     this.primaryConnection = props.primaryConnection;
@@ -50,18 +50,20 @@ export class dvService {
       throw new Error("No connection available");
     }
 
-    if (this.cachedEnvironmentId) {
-      return this.cachedEnvironmentId;
+    const cachedEnvironmentId = this.cachedEnvironmentIds.get(connectionTarget);
+    if (cachedEnvironmentId) {
+      return cachedEnvironmentId;
     }
 
-    if (this.environmentIdRequest) {
-      return this.environmentIdRequest;
+    const inFlightRequest = this.environmentIdRequests.get(connectionTarget);
+    if (inFlightRequest) {
+      return inFlightRequest;
     }
 
     const requestPath =
       "RetrieveCurrentOrganization(AccessType=@p1)?@p1=Microsoft.Dynamics.CRM.EndpointAccessType'Default'";
 
-    this.environmentIdRequest = this.queryData(requestPath, connectionTarget)
+    const environmentIdRequest = this.queryData(requestPath, connectionTarget)
       .then((response) => {
         const environmentId = (response as RetrieveCurrentOrganizationResponse)?.Detail?.EnvironmentId?.trim();
 
@@ -69,14 +71,15 @@ export class dvService {
           throw new Error("RetrieveCurrentOrganization did not return an environment ID");
         }
 
-        this.cachedEnvironmentId = environmentId;
+        this.cachedEnvironmentIds.set(connectionTarget, environmentId);
         return environmentId;
       })
       .finally(() => {
-        this.environmentIdRequest = null;
+        this.environmentIdRequests.delete(connectionTarget);
       });
 
-    return this.environmentIdRequest;
+    this.environmentIdRequests.set(connectionTarget, environmentIdRequest);
+    return environmentIdRequest;
   }
 
   async getTableBrowserUrl(

--- a/src/utils/excelExport.tsx
+++ b/src/utils/excelExport.tsx
@@ -24,7 +24,7 @@ export class ExcelExport {
     const ExcelJS = (excelModule as any).default ?? excelModule;
 
     for (const table of tables) {
-      console.log(`Exporting table: ${table.displayName}`);
+      console.log(`Exporting table: ${table.primaryDisplayName}`);
 
       const workbook = new ExcelJS.Workbook();
 
@@ -38,7 +38,7 @@ export class ExcelExport {
       if (this.vm.excelOptions.includeRelationships) await this.addRelationshipsSheet(workbook, table);
       if (this.vm.excelOptions.includeSolutions) await this.addSolutionsSheet(workbook, table);
 
-      const fileName = `${table.displayName}.xlsx`;
+      const fileName = `${table.primaryDisplayName}.xlsx`;
       const buffer = await workbook.xlsx.writeBuffer();
       const blob = new Blob([buffer], {
         type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -70,7 +70,7 @@ export class ExcelExport {
   private addTableDetailsSheet(workbook: any, table: TableMeta): void {
     const sheet = workbook.addWorksheet("Table Details");
     sheet.addRow(["Table Name", table.tableName]);
-    sheet.addRow(["Display Name", table.displayName]);
+    sheet.addRow(["Display Name", table.primaryDisplayName]);
     table.attributes.map((attr) => {
       sheet.addRow([attr.attributeName, attr.attributeValue]);
     });

--- a/src/utils/excelExport.tsx
+++ b/src/utils/excelExport.tsx
@@ -24,8 +24,6 @@ export class ExcelExport {
     const ExcelJS = (excelModule as any).default ?? excelModule;
 
     for (const table of tables) {
-      console.log(`Exporting table: ${table.primaryDisplayName}`);
-
       const workbook = new ExcelJS.Workbook();
 
       if (this.vm.excelOptions.includeTableDetails) {
@@ -48,9 +46,7 @@ export class ExcelExport {
   }
   async addKeysSheet(workbook: any, table: TableMeta) {
     const sheet = workbook.addWorksheet("Keys");
-    console.log("Adding keys for table:", table.keys.length);
     if (!table.keys || table.keys.length === 0) {
-      console.log("No keys found, fetching from dvService...");
       await this.dvsvc.getKeysMeta(table).then((keys) => {
         table.keys = keys;
       });
@@ -80,14 +76,11 @@ export class ExcelExport {
 
   private async addColumnsSheet(workbook: any, table: TableMeta): Promise<void> {
     const sheet = workbook.addWorksheet("Columns");
-    console.log("Adding columns for table:", table.columns.length);
     if (!table.columns || table.columns.length === 0) {
-      console.log("No columns found, fetching from dvService...");
       await this.dvsvc.getColumnsMeta(table.tableName).then((columns) => {
         table.columns = columns;
       });
     }
-    console.log("Total columns to add:", table.columns.length);
     sheet.addRow(["Column Name", "Display Name", "Data Type", ...this.vm.columnAttributes.map((attr) => attr.name)]);
     table.columns.forEach((column) => {
       const rowData = [
@@ -106,9 +99,7 @@ export class ExcelExport {
 
   private async addPrivilegesSheet(workbook: any, table: TableMeta): Promise<void> {
     const sheet = workbook.addWorksheet("Privileges");
-    console.log("Adding privileges for table:", table.privileges.length);
     if (!table.privileges || table.privileges.length === 0) {
-      console.log("No privileges found, fetching from dvService...");
       await this.dvsvc.getPrivilegesMetadata(table).then((privileges) => {
         table.privileges = privileges;
       });
@@ -127,9 +118,7 @@ export class ExcelExport {
 
   private async addSolutionsSheet(workbook: any, table: TableMeta): Promise<void> {
     const sheet = workbook.addWorksheet("Solutions");
-    console.log("Adding solutions for table:", table.solutions.length);
     if (!table.solutions || table.solutions.length === 0) {
-      console.log("No solutions found, fetching from dvService...");
       await this.dvsvc.getSolutionsForTable(table).then((solutions) => {
         table.solutions = solutions;
       });
@@ -166,9 +155,7 @@ export class ExcelExport {
     const relTypes = ["OneToManyRelationship", "ManyToOneRelationship", "ManyToManyRelationship"];
     for (const type of relTypes) {
       const sheet = workbook.addWorksheet(type);
-      console.log("Adding relationships for table:", table.relationships.length);
       if (!table.relationships || table.relationships.filter((r) => r.type === type).length === 0) {
-        console.log("No relationships found, fetching from dvService...");
         await this.dvsvc.getRelationshipsMeta(table, type).then((relationships) => {
           table.relationships.push(...relationships);
         });


### PR DESCRIPTION
This PR resolves the remaining review-thread issues in the multi-connection comparison changeset. It corrects connection-scoped environment caching, removes stale/debug code, and prevents secondary-only rows from leaking primary-labeled values.

- **Connection-scoped environment ID caching**
  - Replaced single cached/in-flight environment ID state with per-target caches (`primary` / `secondary`) in `dvService`.
  - Prevents secondary URL generation from reusing a primary environment ID.

- **Secondary-only merge correctness**
  - Extended `mergeConnectionComparisonRecords` to accept `primaryDisplayFieldsToClear`.
  - For secondary-only records, clears primary-facing display fields while preserving `secondaryDisplayName`.
  - Applied explicit field clearing at merge call sites (`primaryDisplayName`, `displayName`, `solutionName`, `viewName`, `ruleName`, `flowName`, `keyName`, `privilegeName`, `relationshipName`).

- **UI/export cleanup from review feedback**
  - Removed leftover commented-out `valueGetter` in `MetadataBrowser`.
  - Removed debug `console.log` statements from `excelExport` hot-path methods.

```ts
// connectionComparison.ts
selectedTable.columns = mergeConnectionComparisonRecords(
  primaryColumns,
  secondaryColumns,
  (column) => column.columnName,
  (column) => column.displayName,
  ["displayName"], // clear primary-facing field for secondary-only rows
);
```